### PR TITLE
feat: abstract captureOptions() to MixCommand superclass

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@oclif/command": "1.8.16",
     "@oclif/config": "1.18.2",
+    "@oclif/parser": "^3.8.7",
     "@oclif/plugin-autocomplete": "^1.2.0",
     "@oclif/plugin-help": "3.2.17",
     "axios": "0.26.0",

--- a/src/commands/app-configs/create.ts
+++ b/src/commands/app-configs/create.ts
@@ -83,9 +83,7 @@ should be unique.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsCreate)
-    this.options = flags
+    super.captureOptions()
     debug('flags: %O', flags)
     debug('this.options: %O', flags)
   }

--- a/src/commands/app-configs/create.ts
+++ b/src/commands/app-configs/create.ts
@@ -84,8 +84,6 @@ should be unique.`
 
   captureOptions() {
     super.captureOptions()
-    debug('flags: %O', flags)
-    debug('this.options: %O', flags)
   }
 
   doRequest(client: MixClient, params: AppConfigsCreateParams): Promise<MixResponse> {

--- a/src/commands/app-configs/deploy.ts
+++ b/src/commands/app-configs/deploy.ts
@@ -59,12 +59,6 @@ the application configuration was created.
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsDeploy)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsDeployParams): Promise<MixResponse> {
     debug('doRequest(')
     return AppConfigsAPI.deployAppConfig(client, params)

--- a/src/commands/app-configs/destroy.ts
+++ b/src/commands/app-configs/destroy.ts
@@ -46,12 +46,6 @@ ID when prompted. It can also be pre-confirmed by using the --confirm flag.`
     return {configId: config}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsDestroy)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsDeleteParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppConfigsAPI.deleteAppConfig(client, params)

--- a/src/commands/app-configs/export.ts
+++ b/src/commands/app-configs/export.ts
@@ -53,12 +53,6 @@ on the Mix platform.`
     return {appId, configId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsExport)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsExportParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppConfigsAPI.exportAppConfig(client, params)

--- a/src/commands/app-configs/get.ts
+++ b/src/commands/app-configs/get.ts
@@ -61,12 +61,6 @@ output is brief.`
     return {configId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsGet)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppConfigsAPI.getAppConfig(client, params)

--- a/src/commands/app-configs/list.ts
+++ b/src/commands/app-configs/list.ts
@@ -76,12 +76,6 @@ application IDs can be retrieved using the app-credentials:list command.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppConfigsAPI.listAppConfigs(client, params)

--- a/src/commands/app-configs/undeploy.ts
+++ b/src/commands/app-configs/undeploy.ts
@@ -56,12 +56,6 @@ found in the JSON output of the app-configs:get command.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsUndeploy)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsDeployParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppConfigsAPI.undeployAppConfig(client, params)

--- a/src/commands/app-configs/upgrade.ts
+++ b/src/commands/app-configs/upgrade.ts
@@ -53,12 +53,6 @@ versions. The configuration ID can be retrieved using the app-configs:list comma
     return {configId, useProjectDefault}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppConfigsUpgrade)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppConfigsUpgradeParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppConfigsAPI.ugpradeAppConfig(client, params)

--- a/src/commands/app-credentials/list.ts
+++ b/src/commands/app-credentials/list.ts
@@ -56,13 +56,6 @@ commands.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(AppCredentialsList)
-    debug('flags: %O', flags)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: AppCredentialsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return AppCredentialsAPI.listAppCredentials(client, params)

--- a/src/commands/applications/list.ts
+++ b/src/commands/applications/list.ts
@@ -92,12 +92,6 @@ A number of flags can be used to constrain the returned results.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ApplicationsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ApplicationsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return ApplicationsAPI.listApplications(client, params)

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -48,11 +48,6 @@ access token, it takes care of refreshing it automatically.`
     makeDebug.enable(`${debugSpace},-follow-redirects,-simple-oauth2*`)
   }
 
-  captureOptions() {
-    const {flags} = this.parse(Auth)
-    this.options = flags
-  }
-
   async runWithClientCredentialsGrant() {
     debug('runWithClientCredentialsGrant()')
     const {authServer, clientId, clientSecret, scope} = this.mixCLIConfig!

--- a/src/commands/builds/destroy.ts
+++ b/src/commands/builds/destroy.ts
@@ -107,12 +107,6 @@ It can also be pre-confirmed by using the --confirm flag.`
     return {buildLabel: buildLabelValue}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(BuildsDestroy)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: BuildsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return BuildsAPI.deleteBuild(client, params)

--- a/src/commands/builds/export.ts
+++ b/src/commands/builds/export.ts
@@ -88,12 +88,6 @@ on the Mix platform.`
     return {buildLabel: buildLabelValue}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(BuildsExport)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: BuildsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return BuildsAPI.exportBuild(client, params)

--- a/src/commands/builds/get.ts
+++ b/src/commands/builds/get.ts
@@ -108,12 +108,6 @@ and build version.`
     return {buildLabel: buildLabelValue}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(BuildsGet)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: BuildsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return BuildsAPI.getBuild(client, params)

--- a/src/commands/builds/latest.ts
+++ b/src/commands/builds/latest.ts
@@ -49,12 +49,6 @@ project.`
     return {projectId: project}
   }
 
-  captureOptions() {
-    debug('caputureOptions()')
-    const {flags} = this.parse(BuildsLatest)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: BuildsLatestParams): Promise<MixResponse> {
     debug('doRequest()')
     return BuildsAPI.getBuildsLatest(client, params)

--- a/src/commands/builds/list.ts
+++ b/src/commands/builds/list.ts
@@ -93,12 +93,6 @@ Use this command to list all versions of a build type for a particular project.`
     }
   }
 
-  captureOptions() {
-    debug('caputureOptions()')
-    const {flags} = this.parse(BuildsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: BuildsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return BuildsAPI.listBuilds(client, params)

--- a/src/commands/data-hosts/list.ts
+++ b/src/commands/data-hosts/list.ts
@@ -95,12 +95,6 @@ retrieved using the applications:list command.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(DataHostsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: DataHostsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return DataHostsAPI.listDataHosts(client, params)

--- a/src/commands/deployment-flows/list.ts
+++ b/src/commands/deployment-flows/list.ts
@@ -80,12 +80,6 @@ The organization ID can be retrieved by using the organizations:list command.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(DeploymentFlowsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: DeploymentFlowsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return DeploymentFlowsAPI.listDeploymentFlows(client, params)

--- a/src/commands/engine-packs/list.ts
+++ b/src/commands/engine-packs/list.ts
@@ -44,12 +44,6 @@ Use this command to list the engine packs available to a specific organization.`
     return {orgId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(EnginePacksList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: EnginePacksListParams): Promise<MixResponse> {
     debug('doRequest()')
     return EnginePacksAPI.listEnginePacks(client, params)

--- a/src/commands/environments/list.ts
+++ b/src/commands/environments/list.ts
@@ -65,12 +65,6 @@ Use this command to list all environments available to a specific organization.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(EnvironmentsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: EnvironmentsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return EnvironmentsAPI.listEnvironments(client, params)

--- a/src/commands/geographies/list.ts
+++ b/src/commands/geographies/list.ts
@@ -56,12 +56,6 @@ Use this command to list the geographies available on the platform.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(GeographiesList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: GeographiesListParams): Promise<MixResponse> {
     debug('doRequest()')
     return GeographiesAPI.listGeographies(client, params)

--- a/src/commands/jobs/cancel.ts
+++ b/src/commands/jobs/cancel.ts
@@ -48,12 +48,6 @@ of the original one.`
     return ['job', 'project']
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(JobsCancel)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: JobsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return JobsAPI.deleteJob(client, params)

--- a/src/commands/jobs/get.ts
+++ b/src/commands/jobs/get.ts
@@ -73,12 +73,6 @@ Use this command to get details about a particular job.`
     return {jobId, projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(JobsGet)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: JobsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return JobsAPI.getJob(client, params)

--- a/src/commands/jobs/list.ts
+++ b/src/commands/jobs/list.ts
@@ -63,12 +63,6 @@ Use this command to list all jobs related to a particular project.`
     }
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(JobsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: JobsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return JobsAPI.listJobs(client, params)

--- a/src/commands/language-topics/list.ts
+++ b/src/commands/language-topics/list.ts
@@ -61,12 +61,6 @@ Use this command to list language topics available to a specific organization.`
     return {orgId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(LanguageTopicsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: LanguageTopicsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return LanguageTopicsAPI.listLanguageTopics(client, params)

--- a/src/commands/literals/export.ts
+++ b/src/commands/literals/export.ts
@@ -55,9 +55,7 @@ on the Mix platform.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(LiteralsExport)
-    this.options = flags
+    super.captureOptions()
     this.options.locale = asArray(this.options.locale)
   }
 

--- a/src/commands/literals/import.ts
+++ b/src/commands/literals/import.ts
@@ -63,8 +63,7 @@ It can also be pre-confirmed by using the --confirm flag.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    this.options = this.parse(LiteralsImport).flags
+    super.captureOptions()
     this.action = this.options.replace ? 'import by replacing' : 'import by appending'
   }
 

--- a/src/commands/ontology/export.ts
+++ b/src/commands/ontology/export.ts
@@ -53,9 +53,7 @@ on the Mix platform.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(OntologyExport)
-    this.options = flags
+    super.captureOptions()
     this.options.locale = asArray(this.options.locale)
   }
 

--- a/src/commands/ontology/import.ts
+++ b/src/commands/ontology/import.ts
@@ -51,12 +51,6 @@ It can also be pre-confirmed by using the --confirm flag.`
     return {filePath, projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(OntologyImport)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: OntologyImportParams): Promise<MixResponse> {
     debug('doRequest()')
     return OntologyAPI.appendOntology(client, params)

--- a/src/commands/projects/build.ts
+++ b/src/commands/projects/build.ts
@@ -69,9 +69,7 @@ Use this command to build a project.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsBuild)
-    this.options = flags
+    super.captureOptions()
     this.options.locale = asArray(this.options.locale)
   }
 

--- a/src/commands/projects/configure.ts
+++ b/src/commands/projects/configure.ts
@@ -54,12 +54,6 @@ Note that you cannot add a new locale with this command.
     return {locale, projectId, version}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsConfigure)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsConfigureParams): Promise<MixResponse> {
     debug('doRequest()')
     return ProjectsAPI.configureProject(client, params)

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -118,9 +118,7 @@ provide a description of your project using the --description flag.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsCreate)
-    this.options = flags
+    super.captureOptions()
     this.options.locale = asArray(this.options.locale)
   }
 

--- a/src/commands/projects/destroy.ts
+++ b/src/commands/projects/destroy.ts
@@ -57,12 +57,6 @@ It can also be pre-confirmed by using the --confirm flag.`
     return {projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsDestroy)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return ProjectsAPI.deleteProject(client, params)

--- a/src/commands/projects/export.ts
+++ b/src/commands/projects/export.ts
@@ -59,12 +59,6 @@ Use the --metadata-only flag to export the project metadata JSON file only.`
     return {projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsExport)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsGetParams): Promise<MixResponse> {
     debug('doRequest()')
 

--- a/src/commands/projects/get.ts
+++ b/src/commands/projects/get.ts
@@ -83,12 +83,6 @@ information at a time. The chosen section is specifed using the --table flag.`
     return {projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectGet)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsGetParams): Promise<MixResponse> {
     debug('doRequest()')
     return ProjectsAPI.getProject(client, params)

--- a/src/commands/projects/list.ts
+++ b/src/commands/projects/list.ts
@@ -62,12 +62,6 @@ Use this command to list projects that are part of a particular organization.`
     return {orgId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsList)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsListParams): Promise<MixResponse> {
     debug('doRequest()')
     return ProjectsAPI.listProjects(client, params)

--- a/src/commands/projects/rename.ts
+++ b/src/commands/projects/rename.ts
@@ -42,12 +42,6 @@ Use this command to rename a project.`
     return {displayName, projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsRename)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsRenameParams): Promise<MixResponse> {
     debug('doRequest()')
     return ProjectsAPI.renameProject(client, params)

--- a/src/commands/projects/replace.ts
+++ b/src/commands/projects/replace.ts
@@ -56,12 +56,6 @@ in an incomplete project.`
     return {filePath, projectId}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(ProjectsReplace)
-    this.options = flags
-  }
-
   doRequest(client: MixClient, params: ProjectsReplaceParams): Promise<MixResponse> {
     debug('doRequest()')
     return ProjectsAPI.replaceProject(client, params)

--- a/src/commands/samples/export.ts
+++ b/src/commands/samples/export.ts
@@ -51,9 +51,7 @@ Use this command to export samples for an intent in the project.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(SamplesExport)
-    this.options = flags
+    super.captureOptions()
     this.options.locale = asArray(this.options.locale)
   }
 

--- a/src/commands/samples/import.ts
+++ b/src/commands/samples/import.ts
@@ -69,9 +69,7 @@ a project backup before using this command.`
   }
 
   captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(SamplesImport)
-    this.options = flags
+    super.captureOptions()
     this.action = this.options.replace ? 'import by replacing' : 'import by appending'
   }
 

--- a/src/commands/system/version.ts
+++ b/src/commands/system/version.ts
@@ -51,12 +51,6 @@ export default class SystemVersion extends MixCommand {
     return {}
   }
 
-  captureOptions() {
-    debug('captureOptions()')
-    const {flags} = this.parse(SystemVersion)
-    this.options = flags
-  }
-
   doRequest(client: MixClient): Promise<MixResponse> {
     debug('doRequest(')
     return SystemAPI.getSystemVersion(client)

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -10,6 +10,7 @@ import makeDebug from 'debug'
 import chalk from 'chalk'
 import {cli} from 'cli-ux'
 import {flags} from '@oclif/command'
+import Parser from '@oclif/parser'
 import {table} from 'cli-ux/lib/styled/table'
 import YAML from 'yaml'
 
@@ -118,9 +119,26 @@ that configuration file swiftly.`)
   }
 
   // ------------------------------------------------------------------------
-  // Options treatment
-  //
-  abstract captureOptions(): void
+  /** Options treatment
+   * Explanation:
+   * When creating an oclif command that needs to
+   * parse/validate its flag inputs, you normally need to pass in
+   * the name of the command class as an argument to `this.parse`
+   * (e.g., `const {flags} = this.parse(SampleCommand)`).
+   * In JS, this classname is little more than a reference to a
+   * constructor, a function which also possesses an attribute
+   * called `name`, which can be accessed generically using
+   * `this.constructor` in a superclass. This behaviour is
+   * guaranteed on all non-null objects.
+   */
+
+   captureOptions(): void {
+    debug('captureOptions()')
+    const options = this.constructor as Parser.Input<MixCommand>
+    const {flags} = this.parse(options)
+
+    this.options = flags
+  }
 
   captureOutputFormat(options: Partial<flags.Output>): void {
     debug('captureOutputFormat()')

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -132,7 +132,7 @@ that configuration file swiftly.`)
    * guaranteed on all non-null objects.
    */
 
-   captureOptions(): void {
+  captureOptions(): void {
     debug('captureOptions()')
     const options = this.constructor as Parser.Input<MixCommand>
     const {flags} = this.parse(options)


### PR DESCRIPTION
This PR documents my progress in using the `this.constructor` accessor in `MixCommand` to abstract away the repetitive implementation of `captureOptions()` in (basically) every command.

Those commands that require different or additional behaviour after parsing use a `super` call in order to guarantee that future changes to `captureOptions()` are recorded downstream.

Tests continue to run nominally on my machine\, inexplicably, however, test coverage percentage went *down* across all files.