### PR TITLE
fix: correct set of issues with entities:configure

### DIFF
--- a/src/commands/entities/configure.ts
+++ b/src/commands/entities/configure.ts
@@ -73,18 +73,33 @@ the corresponding property in the entity is not modified.
   ]
 
   static flags = {
-    'anaphora-type': MixFlags.anaphoraTypeFlag({isDefaultIgnored: true}),
-    'data-type': MixFlags.dataTypeFlag({isDefaultIgnored: true}),
-    dynamic: MixFlags.dynamicFlag({isDefaultIgnored: true}),
+    'anaphora-type': {
+      ...MixFlags.anaphoraTypeFlag,
+      default: undefined,
+    },
+    'data-type': {
+      ...MixFlags.dataTypeFlag,
+      default: undefined,
+    },
+    dynamic: {
+      ...MixFlags.dynamicFlag,
+      default: undefined,
+    },
     entity: MixFlags.entityFlag,
     'entity-type': MixFlags.entityTypeFlag,
     'has-a': MixFlags.hasAFlag,
     'is-a': MixFlags.isAFlag,
     locale: MixFlags.regexLocaleFlag,
-    'no-canonicalize': MixFlags.noCanonicalizeFlag({isDefaultIgnored: true}),
+    'no-canonicalize': {
+      ...MixFlags.noCanonicalizeFlag,
+      default: undefined,
+    },
     pattern: MixFlags.patternFlag,
     project: MixFlags.projectFlag,
-    sensitive: MixFlags.sensitiveUserDataFlag({isDefaultIgnored: true}),
+    sensitive: {
+      ...MixFlags.sensitiveUserDataFlag,
+      default: undefined,
+    },
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,
@@ -113,14 +128,14 @@ the corresponding property in the entity is not modified.
     } = options
 
     return {
-      ...(anaphora !== undefined && {anaphora: `ANAPHORA_${anaphora.toUpperCase().replace('-', '_')}`}),
-      ...(dataType !== undefined && {dataType: dataType.toUpperCase().replace('-', '_')}),
+      anaphora,
+      dataType,
       entityName,
       entityType,
       hasA,
       isA,
-      ...(isDynamic !== undefined && {isDynamic}),
-      ...(isSensitive !== undefined && {isSensitive}),
+      isDynamic,
+      isSensitive,
       locale,
       ...(noCanonicalize !== undefined && {canonicalize: !noCanonicalize}),
       pattern,
@@ -171,7 +186,7 @@ the corresponding property in the entity is not modified.
       pattern,
     } = options
 
-    // Entity types 'relational' require mandatory flags upon creation or
+    // Entity type 'relational' requires mandatory flags upon creation or
     // conversion but not for updates. However, for regex entities, locale and
     // pattern must be provided together for updates.
     // Command bails out if mandatory parameters are missing.

--- a/src/commands/entities/configure.ts
+++ b/src/commands/entities/configure.ts
@@ -73,33 +73,18 @@ the corresponding property in the entity is not modified.
   ]
 
   static flags = {
-    'anaphora-type': {
-      ...MixFlags.anaphoraTypeFlag,
-      default: undefined,
-    },
-    'data-type': {
-      ...MixFlags.dataTypeFlag,
-      default: undefined,
-    },
-    dynamic: {
-      ...MixFlags.dynamicFlag,
-      default: undefined,
-    },
+    'anaphora-type': MixFlags.ignoreDefault(MixFlags.anaphoraTypeFlag),
+    'data-type': MixFlags.ignoreDefault(MixFlags.dataTypeFlag),
+    dynamic: MixFlags.ignoreDefault(MixFlags.dynamicFlag),
     entity: MixFlags.entityFlag,
     'entity-type': MixFlags.entityTypeFlag,
     'has-a': MixFlags.hasAFlag,
     'is-a': MixFlags.isAFlag,
     locale: MixFlags.regexLocaleFlag,
-    'no-canonicalize': {
-      ...MixFlags.noCanonicalizeFlag,
-      default: undefined,
-    },
+    'no-canonicalize': MixFlags.ignoreDefault(MixFlags.noCanonicalizeFlag),
     pattern: MixFlags.patternFlag,
     project: MixFlags.projectFlag,
-    sensitive: {
-      ...MixFlags.sensitiveUserDataFlag,
-      default: undefined,
-    },
+    sensitive: MixFlags.ignoreDefault(MixFlags.sensitiveUserDataFlag),
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,

--- a/src/commands/entities/configure.ts
+++ b/src/commands/entities/configure.ts
@@ -15,7 +15,7 @@ import * as MixFlags from '../../utils/flags'
 import {EntitiesConfigureParams, MixClient, MixResponse, MixResult} from '../../mix/types'
 import MixCommand from '../../utils/base/mix-command'
 import {DomainOption} from '../../utils/validations'
-import {validateRegexEntityParams, validateRuleBasedEntityParams} from '../../utils/validations'
+import {validateRegexEntityParams} from '../../utils/validations'
 
 const debug = makeDebug('mix:commands:entities:configure')
 
@@ -73,18 +73,18 @@ the corresponding property in the entity is not modified.
   ]
 
   static flags = {
-    'anaphora-type': MixFlags.anaphoraTypeFlag,
-    'data-type': MixFlags.dataTypeFlag,
-    dynamic: MixFlags.dynamicFlag,
+    'anaphora-type': MixFlags.anaphoraTypeFlag({isDefaultIgnored: true}),
+    'data-type': MixFlags.dataTypeFlag({isDefaultIgnored: true}),
+    dynamic: MixFlags.dynamicFlag({isDefaultIgnored: true}),
     entity: MixFlags.entityFlag,
-    'entity-type': MixFlags.withEntityTypeFlag,
+    'entity-type': MixFlags.entityTypeFlag,
     'has-a': MixFlags.hasAFlag,
     'is-a': MixFlags.isAFlag,
     locale: MixFlags.regexLocaleFlag,
-    'no-canonicalize': MixFlags.noCanonicalizeFlag,
+    'no-canonicalize': MixFlags.noCanonicalizeFlag({isDefaultIgnored: true}),
     pattern: MixFlags.patternFlag,
     project: MixFlags.projectFlag,
-    sensitive: MixFlags.sensitiveUserDataFlag,
+    sensitive: MixFlags.sensitiveUserDataFlag({isDefaultIgnored: true}),
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,
@@ -113,16 +113,16 @@ the corresponding property in the entity is not modified.
     } = options
 
     return {
-      anaphora: `ANAPHORA_${anaphora.toUpperCase().replace('-', '_')}`,
-      canonicalize: !noCanonicalize,
-      dataType: dataType.toUpperCase().replace('-', '_'),
+      ...(anaphora !== undefined && {anaphora: `ANAPHORA_${anaphora.toUpperCase().replace('-', '_')}`}),
+      ...(dataType !== undefined && {dataType: dataType.toUpperCase().replace('-', '_')}),
       entityName,
       entityType,
       hasA,
       isA,
-      isDynamic,
-      isSensitive,
+      ...(isDynamic !== undefined && {isDynamic}),
+      ...(isSensitive !== undefined && {isSensitive}),
       locale,
+      ...(noCanonicalize !== undefined && {canonicalize: !noCanonicalize}),
       pattern,
       projectId,
     }
@@ -141,7 +141,7 @@ the corresponding property in the entity is not modified.
 
   setRequestActionMessage(options: any) {
     debug('setRequestActionMessage()')
-    this.requestActionMessage = `Configuring entity ${options.name} in project ${options.project}`
+    this.requestActionMessage = `Configuring entity ${chalk.cyan(options.entity)} in project ${chalk.cyan(options.project)}`
   }
 
   transformResponse(result: MixResult) {
@@ -167,21 +167,17 @@ the corresponding property in the entity is not modified.
 
     const {
       'entity-type': entityType,
-      'has-a': hasA,
-      'is-a': isA,
       locale,
       pattern,
     } = options
 
-    // Entity types 'regex' and 'relational' require mandatory flags.
+    // Entity types 'relational' require mandatory flags upon creation or
+    // conversion but not for updates. However, for regex entities, locale and
+    // pattern must be provided together for updates.
     // Command bails out if mandatory parameters are missing.
     // Extraneous parameters are ignored.
     if (entityType === 'regex') {
       validateRegexEntityParams(locale, pattern)
-    }
-
-    if (entityType === 'relational') {
-      validateRuleBasedEntityParams(hasA, isA)
     }
   }
 }

--- a/src/commands/entities/create.ts
+++ b/src/commands/entities/create.ts
@@ -73,18 +73,18 @@ explicitly provided.
   ]
 
   static flags = {
-    'anaphora-type': MixFlags.anaphoraTypeFlag(),
-    'data-type': MixFlags.dataTypeFlag(),
-    dynamic: MixFlags.dynamicFlag(),
+    'anaphora-type': MixFlags.anaphoraTypeFlag,
+    'data-type': MixFlags.dataTypeFlag,
+    dynamic: MixFlags.dynamicFlag,
     'entity-type': MixFlags.entityTypeFlag,
     'has-a': MixFlags.hasAFlag,
     'is-a': MixFlags.isAFlag,
     locale: MixFlags.regexLocaleFlag,
     name: MixFlags.entityNameFlag,
-    'no-canonicalize': MixFlags.noCanonicalizeFlag(),
+    'no-canonicalize': MixFlags.noCanonicalizeFlag,
     pattern: MixFlags.patternFlag,
     project: MixFlags.projectFlag,
-    sensitive: MixFlags.sensitiveUserDataFlag(),
+    sensitive: MixFlags.sensitiveUserDataFlag,
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,
@@ -113,9 +113,9 @@ explicitly provided.
     } = options
 
     return {
-      anaphora: `ANAPHORA_${anaphora.toUpperCase().replace('-', '_')}`,
+      anaphora,
       canonicalize: !noCanonicalize,
-      dataType: dataType.toUpperCase().replace('-', '_'),
+      dataType,
       entityType: entityType,
       hasA,
       isA,

--- a/src/commands/entities/create.ts
+++ b/src/commands/entities/create.ts
@@ -73,18 +73,18 @@ explicitly provided.
   ]
 
   static flags = {
-    'anaphora-type': MixFlags.anaphoraTypeFlag,
-    'data-type': MixFlags.dataTypeFlag,
-    dynamic: MixFlags.dynamicFlag,
-    'entity-type': MixFlags.withEntityTypeFlag,
+    'anaphora-type': MixFlags.anaphoraTypeFlag(),
+    'data-type': MixFlags.dataTypeFlag(),
+    dynamic: MixFlags.dynamicFlag(),
+    'entity-type': MixFlags.entityTypeFlag,
     'has-a': MixFlags.hasAFlag,
     'is-a': MixFlags.isAFlag,
     locale: MixFlags.regexLocaleFlag,
     name: MixFlags.entityNameFlag,
-    'no-canonicalize': MixFlags.noCanonicalizeFlag,
+    'no-canonicalize': MixFlags.noCanonicalizeFlag(),
     pattern: MixFlags.patternFlag,
     project: MixFlags.projectFlag,
-    sensitive: MixFlags.sensitiveUserDataFlag,
+    sensitive: MixFlags.sensitiveUserDataFlag(),
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,

--- a/src/mix/api/utils/entities-helpers.ts
+++ b/src/mix/api/utils/entities-helpers.ts
@@ -52,11 +52,17 @@ const buildEntityPayload = (params: any) => {
   entityTypeKey = entityType === 'rule-based' ? 'ruleBased' : entityType
   entityTypeKey = `${entityTypeKey}Entity`
 
+  const adjustedAnaphora = anaphora !== undefined &&
+    `ANAPHORA_${anaphora.toUpperCase().replace('-', '_')}`
+
+  const adjustedDataType = dataType !== undefined &&
+    dataType.toUpperCase().replace('-', '_')
+
   return {
     [entityTypeKey]: {
-      ...(anaphora !== undefined && {anaphora}),
+      ...(anaphora !== undefined && {anaphora: adjustedAnaphora}),
       ...(entityType === 'list') && {data: {}},
-      ...(dataType !== undefined && {dataType}),
+      ...(dataType !== undefined && {dataType: adjustedDataType}),
       ...(hasA !== undefined && {hasA: {entities: hasA}}),
       ...(isA !== undefined && {isA}),
       ...(isDynamic !== undefined && {isDynamic}),

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -61,9 +61,9 @@ export const projectDescWithDefault = `project ID (defaults to ${projectEnvVarDe
 // Flag options
 export const buildTypeOptions = ['asr', 'dialog', 'nlu']
 
-export const anaphoraTypeFlag = flags.string({
-  default: AnaphoraDefault,
+export const anaphoraTypeFlag = ({isDefaultIgnored = false} = {}) => flags.string({
   description: 'anaphora type',
+  ...(!isDefaultIgnored && {default: AnaphoraDefault}),
   options: Object.keys(Anaphoras).sort(),
 })
 
@@ -96,9 +96,9 @@ export const confirmFlag = flags.string({
   description: 'skip confirmation prompt by pre-supplying value',
 })
 
-export const dataTypeFlag = flags.string({
-  default: DataTypeDefault,
+export const dataTypeFlag = ({isDefaultIgnored = false} = {}) => flags.string({
   description: 'data type of entity',
+  ...(!isDefaultIgnored && {default: DataTypeDefault}),
   options: Object.keys(DataTypes).sort(),
 })
 
@@ -119,13 +119,19 @@ export const dataPackTopicFlag = flags.string({
   required: true,
 })
 
-export const dynamicFlag = flags.boolean({
+export const dynamicFlag = ({isDefaultIgnored = false} = {}) => flags.boolean({
   description: 'make list entity dynamic',
-  default: false,
+  ...(!isDefaultIgnored && {default: false}),
 })
 
 export const enginePackFlag = flags.string({
   description: 'engine pack ID (UUID format)',
+})
+
+export const entityTypeFlag = flags.string({
+  description: 'entity type',
+  options: Object.keys(Entities).sort(),
+  required: true,
 })
 
 export const envGeoIDFlag = flags.integer({
@@ -262,9 +268,9 @@ export const nluModelTypeFlag = flags.string({
   options: ['accurate', 'fast'],
 })
 
-export const noCanonicalizeFlag = flags.boolean({
-  default: false,
+export const noCanonicalizeFlag = ({isDefaultIgnored = false} = {}) => flags.boolean({
   description: 'prevent canonicalization',
+  ...(!isDefaultIgnored && {default: false}),
 })
 
 export const offsetFlag = flags.integer({
@@ -340,9 +346,9 @@ export const runtimeApplicationFlag = flags.string({
   required: true,
 })
 
-export const sensitiveUserDataFlag = flags.boolean({
-  default: false,
+export const sensitiveUserDataFlag = ({isDefaultIgnored = false} = {}) => flags.boolean({
   description: 'mask user sentitive data in logs',
+  ...(!isDefaultIgnored && {default: false}),
 })
 
 export const showAllOrganizationsFlag = flags.boolean({

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -61,9 +61,9 @@ export const projectDescWithDefault = `project ID (defaults to ${projectEnvVarDe
 // Flag options
 export const buildTypeOptions = ['asr', 'dialog', 'nlu']
 
-export const anaphoraTypeFlag = ({isDefaultIgnored = false} = {}) => flags.string({
+export const anaphoraTypeFlag = flags.string({
+  default: AnaphoraDefault,
   description: 'anaphora type',
-  ...(!isDefaultIgnored && {default: AnaphoraDefault}),
   options: Object.keys(Anaphoras).sort(),
 })
 
@@ -96,9 +96,9 @@ export const confirmFlag = flags.string({
   description: 'skip confirmation prompt by pre-supplying value',
 })
 
-export const dataTypeFlag = ({isDefaultIgnored = false} = {}) => flags.string({
+export const dataTypeFlag = flags.string({
+  default: DataTypeDefault,
   description: 'data type of entity',
-  ...(!isDefaultIgnored && {default: DataTypeDefault}),
   options: Object.keys(DataTypes).sort(),
 })
 
@@ -119,9 +119,9 @@ export const dataPackTopicFlag = flags.string({
   required: true,
 })
 
-export const dynamicFlag = ({isDefaultIgnored = false} = {}) => flags.boolean({
+export const dynamicFlag = flags.boolean({
+  default: false,
   description: 'make list entity dynamic',
-  ...(!isDefaultIgnored && {default: false}),
 })
 
 export const enginePackFlag = flags.string({
@@ -268,9 +268,9 @@ export const nluModelTypeFlag = flags.string({
   options: ['accurate', 'fast'],
 })
 
-export const noCanonicalizeFlag = ({isDefaultIgnored = false} = {}) => flags.boolean({
+export const noCanonicalizeFlag = flags.boolean({
+  default: false,
   description: 'prevent canonicalization',
-  ...(!isDefaultIgnored && {default: false}),
 })
 
 export const offsetFlag = flags.integer({
@@ -346,9 +346,9 @@ export const runtimeApplicationFlag = flags.string({
   required: true,
 })
 
-export const sensitiveUserDataFlag = ({isDefaultIgnored = false} = {}) => flags.boolean({
+export const sensitiveUserDataFlag = flags.boolean({
+  default: false,
   description: 'mask user sentitive data in logs',
-  ...(!isDefaultIgnored && {default: false}),
 })
 
 export const showAllOrganizationsFlag = flags.boolean({

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -61,13 +61,19 @@ export const projectDescWithDefault = `project ID (defaults to ${projectEnvVarDe
 // Flag options
 export const buildTypeOptions = ['asr', 'dialog', 'nlu']
 
+// Flag helpers
+export const ignoreDefault = <T>(flag: T): T => ({
+  ...flag,
+  default: undefined,
+})
+
+// Flag objects
 export const anaphoraTypeFlag = flags.string({
   default: AnaphoraDefault,
   description: 'anaphora type',
   options: Object.keys(Anaphoras).sort(),
 })
 
-// Flag objects
 export const appConfigurationFlag = flags.integer({
   char: appConfigurationShortcut,
   description: 'application configuration ID',

--- a/test/commands/entities/configure.test.ts
+++ b/test/commands/entities/configure.test.ts
@@ -22,6 +22,7 @@ describe('entities:configure', () => {
     )
     .stdout()
     .command(['entities:configure',
+      '--data-type', 'not-set',
       '--entity', td.request.entity,
       '--entity-type', td.request.entityType,
       '--project', td.request.project,
@@ -54,16 +55,20 @@ describe('entities:configure', () => {
 
   test
     .env(testEnvData.env)
-    .stderr()
+    .nock(serverURL, api => api
+      .put(`/v4/projects/${td.request.project}/entities/${td.request.entity}`, td.configureRelationalEntityBody)
+      .reply(200, td.getEntityResponse)
+    )
+    .stdout()
     .command(['entities:configure',
+      '--data-type', 'not-set',
       '--entity', td.request.entity,
       '--entity-type', 'relational',
       '--project', td.request.project,
     ])
-    .catch(ctx => {
-      expect(ctx.message).to.contain('Relational entities require has-a and/or is-a relation')
+    .it('configures a relational entity', ctx => {
+      expect(ctx.stdout).to.contain(`Entity ${td.request.entity} with ID ${td.getEntityResponse.entity.listEntity.id} was updated`)
     })
-    .it('errors out when mandatory parameters are missing to configure a relational entity')
 
   test
     .env(testEnvData.env)
@@ -73,6 +78,7 @@ describe('entities:configure', () => {
     )
     .stdout()
     .command(['entities:configure',
+      '--data-type', 'not-set',
       '--entity', td.request.invalidEntity,
       '--entity-type', td.request.entityType,
       '--project', td.request.project,
@@ -90,6 +96,7 @@ describe('entities:configure', () => {
     )
     .stdout()
     .command(['entities:configure',
+      '--data-type', 'not-set',
       '--entity', td.request.entity,
       '--entity-type', td.request.entityType,
       '--project', td.request.unknownProject,

--- a/test/commands/entities/entities-test-data.ts
+++ b/test/commands/entities/entities-test-data.ts
@@ -19,11 +19,15 @@ module.exports = {
   },
   configureListEntityBody: {
     listEntity: {
-      anaphora: 'ANAPHORA_NOT_SET',
-      data: {},
       dataType: 'NOT_SET',
-      isDynamic: false,
-      settings: { canonicalize: true, isSensitive: false },
+      data: {},
+      settings: {},
+    }
+  },
+  configureRelationalEntityBody: {
+    relationalEntity: {
+      dataType: "NOT_SET",
+      settings: {},
     }
   },
   convertEntityBody: {


### PR DESCRIPTION
entities:configure had a number of issues:

- It was listing `undefined` instead of the entity name in the action message
- The entity-type flag was not required
- isA and hasA was treated as mandatory for type relational and they are not
- anaphora-type, no-canonicalize, data-type, dynamic and sensitive all had defaults which were ending up being used as update values in the body which went against the contract that properties not given explicit update values would be left unmodified.
