### PR TITLE
fix: add MIX_PROJECT as default for project flag in all intents commands

### DIFF
--- a/src/commands/intents/create.ts
+++ b/src/commands/intents/create.ts
@@ -29,7 +29,7 @@ Use this command to create a new intent in a project.`
 
   static flags = {
     name: MixFlags.intentNameFlag,
-    project: MixFlags.projectFlag,
+    project: MixFlags.projectWithDefaultFlag,
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,

--- a/src/commands/intents/destroy.ts
+++ b/src/commands/intents/destroy.ts
@@ -30,7 +30,7 @@ Use this command to permanently delete an intent from a project.`
   static flags = {
     confirm: MixFlags.confirmFlag,
     intent: MixFlags.intentFlag,
-    project: MixFlags.projectFlag,
+    project: MixFlags.projectWithDefaultFlag,
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,

--- a/src/commands/intents/get.ts
+++ b/src/commands/intents/get.ts
@@ -28,7 +28,7 @@ Use this command to get details about a particular intent in a project.`
 
   static flags = {
     intent: MixFlags.intentFlag,
-    project: MixFlags.projectFlag,
+    project: MixFlags.projectWithDefaultFlag,
     // output flags
     json: MixFlags.jsonFlag,
     ...MixFlags.tableFlags({

--- a/src/commands/intents/list.ts
+++ b/src/commands/intents/list.ts
@@ -27,7 +27,7 @@ Use this command to list all intents available in a specific project.`
   ]
 
   static flags = {
-    project: MixFlags.projectFlag,
+    project: MixFlags.projectWithDefaultFlag,
     // output flags
     json: MixFlags.jsonFlag,
     ...MixFlags.tableFlags({except: ['extended']}),

--- a/src/commands/intents/rename.ts
+++ b/src/commands/intents/rename.ts
@@ -30,7 +30,7 @@ Use this command to rename an intent in a project.`
   static flags = {
     intent: MixFlags.intentFlag,
     name: MixFlags.intentNameFlag,
-    project: MixFlags.projectFlag,
+    project: MixFlags.projectWithDefaultFlag,
     // output flags
     json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,


### PR DESCRIPTION
Caught this during verification: the project flag needs to default to MIX_PROJECT if present.