### PR TITLE
fix: make consistent use of color in entities commands output

### DIFF
--- a/src/commands/entities/create.ts
+++ b/src/commands/entities/create.ts
@@ -141,7 +141,7 @@ explicitly provided.
 
   setRequestActionMessage(options: any) {
     debug('setRequestActionMessage()')
-    this.requestActionMessage = `Creating entity ${options.name} in project ${options.project}`
+    this.requestActionMessage = `Creating entity ${chalk.cyan(options.name)} in project ${chalk.cyan(options.project)}`
   }
 
   transformResponse(result: MixResult) {

--- a/src/commands/entities/destroy.ts
+++ b/src/commands/entities/destroy.ts
@@ -65,12 +65,12 @@ Use this command to permanently delete an entity from a project.`
   outputHumanReadable(_transformedData: any) {
     debug('outputHumanReadable()')
     // Add entity name as endpoint response does not provide it
-    this.log(`Entity ${this.options.entity} was deleted.`)
+    this.log(`Entity ${chalk.cyan(this.options.entity)} was deleted.`)
   }
 
   setRequestActionMessage(options: any) {
     debug('setRequestActionMessage()')
-    this.requestActionMessage = `Destroying entity ${options.entity}`
+    this.requestActionMessage = `Destroying entity ${chalk.cyan(options.entity)} in project ${chalk.cyan(options.project)}`
   }
 
   warnBeforeConfirmation() {

--- a/src/commands/entities/get.ts
+++ b/src/commands/entities/get.ts
@@ -5,6 +5,7 @@
  * This source code is licensed under the Apache-2.0 license found in
  * the LICENSE file in the root directory of this source tree.  */
 
+import chalk from 'chalk'
 import {flags} from '@oclif/command'
 import makeDebug from 'debug'
 
@@ -86,7 +87,7 @@ Use this command to get details about a particular entity in a project.`
 
   setRequestActionMessage(options: any) {
     debug('setRequestActionMessage()')
-    this.requestActionMessage = `Retrieving details for entity ${options.entity}`
+    this.requestActionMessage = `Retrieving details for entity ${chalk.cyan(options.entity)} in ${chalk.cyan(options.project)}`
   }
 
   transformResponse(result: MixResult) {

--- a/src/commands/entities/list.ts
+++ b/src/commands/entities/list.ts
@@ -6,6 +6,7 @@
  * the LICENSE file in the root directory of this source tree.
  */
 
+import chalk from 'chalk'
 import {flags} from '@oclif/command'
 import makeDebug from 'debug'
 
@@ -78,7 +79,7 @@ Use this command to list all entities available in a specific project.`
 
   setRequestActionMessage(options: any) {
     debug('setRequestActionMessage()')
-    this.requestActionMessage = `Retrieving entities for project ID ${options.project}`
+    this.requestActionMessage = `Retrieving entities for project ID ${chalk.cyan(options.project)}`
   }
 
   transformResponse(result: MixResult) {

--- a/src/commands/entities/rename.ts
+++ b/src/commands/entities/rename.ts
@@ -68,7 +68,7 @@ Use this command to rename an entity in a project.`
 
   setRequestActionMessage(options: any) {
     debug('setRequestActionMessage()')
-    this.requestActionMessage = `Renaming entity ${options.entity} in project ${options.project}`
+    this.requestActionMessage = `Renaming entity ${chalk.cyan(options.entity)} in project ${chalk.cyan(options.project)}`
   }
 
   transformResponse(result: MixResult) {


### PR DESCRIPTION
As I was testing entities commands, I noted where cyan was missing from the output. I also added the project ID where it made sense.