### PR TITLE
fix: remove N/As from entities:get output

### DIFF
--- a/src/commands/entities/get.ts
+++ b/src/commands/entities/get.ts
@@ -19,7 +19,16 @@ const debug = makeDebug('mix:commands:entities:get')
 export default class EntitiesGet extends MixCommand {
   static description = `get details about an entity
 
-Use this command to get details about a particular entity in a project.`
+Use this command to get details about a particular entity in a project.
+
+The set of properties listed in the human-readable output of this command
+varies with the type of the entity queried. However, the CSV output provides a
+column for each of the properties present in the superset of all entity type
+properties. This way, a consistent set of columns is always presented.
+
+Use the --json or --yaml flag to see the original data returned by the
+server.
+`
 
   static examples = [
     'mix entities:get -P 1922 -E DrinkSize',
@@ -27,12 +36,13 @@ Use this command to get details about a particular entity in a project.`
 
   static flags = {
     entity: MixFlags.entityFlag,
-    json: MixFlags.jsonFlag,
     project: MixFlags.projectWithDefaultFlag,
     ...MixFlags.tableFlags({
       except: ['extended', 'no-header', 'filter', 'sort'],
       useColumnsWithCSVOnly: true,
     }),
+    // output flags
+    json: MixFlags.jsonFlag,
     yaml: MixFlags.yamlFlag,
   }
 

--- a/src/commands/entities/get.ts
+++ b/src/commands/entities/get.ts
@@ -81,7 +81,7 @@ Use this command to get details about a particular entity in a project.`
 
   outputHumanReadable(transformedData: any) {
     debug('outputHumanReadable()')
-    this.outputAsKeyValuePairs(transformedData, this.columns)
+    this.outputAsKeyValuePairs(transformedData, this.columns, true /* skip NAs */)
   }
 
   setRequestActionMessage(options: any) {

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -373,9 +373,14 @@ that configuration file swiftly.`)
     }
   }
 
-  outputAsKeyValuePairs(transformedData: any, columns: Columns): void {
+  outputAsKeyValuePairs(transformedData: any, columns: Columns, skipNA = false): void {
     debug('outputAsKeyValuePairs()')
     for (const key of Object.keys(columns)) {
+      if (transformedData[key] === undefined && skipNA) {
+        // skip key-value pairs with undefined value to avoid cluttering the output
+        continue
+      }
+
       const col = columns[key]
 
       this.log(`${chalk.bold(col.header)}: ${asValueOrNA(key, transformedData[key])}`)


### PR DESCRIPTION
entities:get used to return the superset of key-value pairs. As a good number of keys don't apply to each entity type, that ended up creating a non-negligible number of lines with value "N/A". This was cluttering the output.

Only keys with defined values are now displayed in human-readable output. However, all keys were kept in the CSV output as to let users write a single parser.