### PR TITLE
fix: change from --name to --new-name in rename commands

### DIFF
--- a/src/commands/entities/rename.ts
+++ b/src/commands/entities/rename.ts
@@ -24,13 +24,16 @@ export default class EntitiesRename extends MixCommand {
 Use this command to rename an entity in a project.`
 
   static examples = [
-    '$ mix entities:rename -P 1922 -E DrinkSize --name DrinkFormat',
+    '$ mix entities:rename -P 1922 -E DrinkSize --new-name DrinkFormat',
   ]
 
   static flags = {
     entity: MixFlags.entityFlag,
     json: MixFlags.jsonFlag,
-    name: MixFlags.entityNameFlag,
+    'new-name': flags.string({
+      required: true,
+      description: 'new entity name',
+    }),
     project: MixFlags.projectWithDefaultFlag,
     yaml: MixFlags.yamlFlag,
   }
@@ -44,7 +47,7 @@ Use this command to rename an entity in a project.`
     debug('buildRequestParameters()')
     const {
       entity: entityName,
-      name: newEntityName,
+      'new-name': newEntityName,
       project: projectId,
     } = options
 

--- a/src/commands/intents/rename.ts
+++ b/src/commands/intents/rename.ts
@@ -24,12 +24,15 @@ export default class IntentsRename extends MixCommand {
 Use this command to rename an intent in a project.`
 
   static examples = [
-    '$ mix intents:rename -P 1922 -I ORDER_DRINK --name ORDER_COFFEE',
+    '$ mix intents:rename -P 1922 -I ORDER_DRINK --new-name ORDER_COFFEE',
   ]
 
   static flags = {
     intent: MixFlags.intentFlag,
-    name: MixFlags.intentNameFlag,
+    'new-name': flags.string({
+      required: true,
+      description: 'new intent name',
+    }),
     project: MixFlags.projectWithDefaultFlag,
     // output flags
     json: MixFlags.jsonFlag,
@@ -45,7 +48,7 @@ Use this command to rename an intent in a project.`
     debug('buildRequestParameters()')
     const {
       intent: intentName,
-      name: newIntentName,
+      'new-name': newIntentName,
       project: projectId,
     } = options
 

--- a/src/commands/projects/rename.ts
+++ b/src/commands/projects/rename.ts
@@ -22,10 +22,13 @@ export default class ProjectsRename extends MixCommand {
   
 Use this command to rename a project.`
 
-  static examples = ['$ mix projects:rename -P 1922 -n ACME']
+  static examples = ['$ mix projects:rename -P 1922 --new-name ACME']
 
   static flags = {
-    name: MixFlags.projectNameFlag,
+    'new-name': flags.string({
+      required: true,
+      description: 'new project name',
+    }),
     ...MixFlags.machineOutputFlags,
     project: MixFlags.projectWithDefaultFlag,
   }
@@ -37,7 +40,10 @@ Use this command to rename a project.`
 
   async buildRequestParameters(options: Partial<flags.Output>): Promise<ProjectsRenameParams> {
     debug('buildRequestParameters()')
-    const {name: displayName, project: projectId} = options
+    const {
+      'new-name': displayName,
+      project: projectId,
+    } = options
 
     return {displayName, projectId}
   }

--- a/test/commands/entities/rename.test.ts
+++ b/test/commands/entities/rename.test.ts
@@ -23,7 +23,7 @@ describe('entities:rename', () => {
     .stdout()
     .command(['entities:rename',
       '--entity', td.request.entity,
-      '--name', td.request.newName,
+      '--new-name', td.request.newName,
       '--project', td.request.project,
     ])
     .it('renames an entity', ctx => {
@@ -63,7 +63,7 @@ describe('entities:rename', () => {
     .stdout()
     .command(['entities:rename',
       '--entity', td.request.entity,
-      '--name', td.request.newName,
+      '--new-name', td.request.newName,
       '--project', td.request.unknownProject,
     ])
     .catch(ctx => {

--- a/test/commands/intents/rename.test.ts
+++ b/test/commands/intents/rename.test.ts
@@ -23,7 +23,7 @@ describe('intents:rename', () => {
     .stdout()
     .command(['intents:rename',
       '--intent', td.request.intent,
-      '--name', td.request.newName,
+      '--new-name', td.request.newName,
       '--project', td.request.project,
     ])
     .it('renames an intent', ctx => {
@@ -63,7 +63,7 @@ describe('intents:rename', () => {
     .stdout()
     .command(['intents:rename',
       '--intent', td.request.intent,
-      '--name', td.request.newName,
+      '--new-name', td.request.newName,
       '--project', td.request.unknownProject,
     ])
     .catch(ctx => {

--- a/test/commands/projects/rename.test.ts
+++ b/test/commands/projects/rename.test.ts
@@ -24,7 +24,7 @@ describe('projects:rename command', () => {
     )
     .command(['projects:rename',
       `-P=${td.rename.flags.project}`,
-      `-n=${td.rename.flags.name}`]
+      `--new-name=${td.rename.flags.name}`]
     )
     .it('renames a project', ctx => {
       const [firstLine] = ctx.stdout.split('\n').map(ln => ln.trim())


### PR DESCRIPTION
As discussed, aligning all rename commands to use `--new-name` instead of `--name`. The shortcut `-n` was also removed.