### PR TITLE
fix: add warning regarding pattern values

### DIFF
--- a/src/commands/entities/configure.ts
+++ b/src/commands/entities/configure.ts
@@ -38,7 +38,8 @@ to specific entity types only.
 Regex entities make use of regular expressions specific to a single
 locale. The --pattern and --locale flags matter only to entities
 of type "regex". It is recommended to surround the pattern
-value with quotes, especially if the "\\" is used in the pattern.
+value with quotes, especially if the escape character "\\" is used
+in the pattern. See examples below.
 
 Relationial entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be

--- a/src/commands/entities/configure.ts
+++ b/src/commands/entities/configure.ts
@@ -37,7 +37,8 @@ to specific entity types only.
 
 Regex entities make use of regular expressions specific to a single
 locale. The --pattern and --locale flags matter only to entities
-of type "regex".
+of type "regex". It is recommended to surround the pattern
+value with quotes, especially if the "\\" is used in the pattern.
 
 Relationial entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be
@@ -61,7 +62,7 @@ the corresponding property in the entity is not modified.
     '',
     'Configure a regex entity',
     '$ mix entities:configure -P 1922 -E PHONE_NUMBER --entity-type regex \\',
-    '  --locale en-US --pattern \\d{10} --sensitive --no-canonicalize \\',
+    '  --locale en-US --pattern "\\d{10}" --sensitive --no-canonicalize \\',
     '  --anaphora-type not-set --data-type digits',
     '',
     'Configure a relational entity',

--- a/src/commands/entities/convert.ts
+++ b/src/commands/entities/convert.ts
@@ -30,11 +30,12 @@ entity type, you will have to provide additional information as
 explained below.
 
 Regex entities make use of regular expressions specific to a single
-locale. Use the --pattern flag to provide the regular expression
-for the converted entity. The regular expression provided gets
-applied to all locales in the project. Use the entities:configure
-command to update the regular expression on a per locale basis
-if needed.
+locale. Use the --pattern flag to provide the regular expression for
+the converted entity. It is recommended to surround the pattern value
+with quotes, especially if the "\\" is used in the pattern. The regular
+expression provided gets applied to all locales in the project. Use the
+entities:configure command to update the regular expression on a per
+locale basis if needed.
 
 Relational entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be
@@ -53,7 +54,7 @@ type of entity.
     '',
     'Convert an entity to a regex entity',
     '$ mix entities:convert -P 1922 -E MY_ENTITY --to-entity-type regex \\',
-    '  --pattern \\d{10}',
+    '  --pattern "\\d{10}"',
     '',
     'Convert an entity to a relational entity',
     '$ mix entities:convert -P 1922 --E MY_ENTITY --to-entity-type relational',

--- a/src/commands/entities/convert.ts
+++ b/src/commands/entities/convert.ts
@@ -32,10 +32,11 @@ explained below.
 Regex entities make use of regular expressions specific to a single
 locale. Use the --pattern flag to provide the regular expression for
 the converted entity. It is recommended to surround the pattern value
-with quotes, especially if the "\\" is used in the pattern. The regular
-expression provided gets applied to all locales in the project. Use the
-entities:configure command to update the regular expression on a per
-locale basis if needed.
+with quotes, especially if the escape character "\\" is used in the
+pattern (see examples below). The regular expression provided gets
+applied to the entity across all locales in the project. If the regular
+expression for the entity is locale-dependent, then use the entities:configure
+command to update the regular expression for the relevant locales.
 
 Relational entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be

--- a/src/commands/entities/create.ts
+++ b/src/commands/entities/create.ts
@@ -33,7 +33,8 @@ attributes are mandatory and apply to specific entity types only.
 Regex entities make use of regular expressions specific to a single
 locale. The --pattern and --locale flags must be set when creating
 an entity of type "regex". It is recommended to surround the pattern
-value with quotes, especially if the "\\" is used in the pattern.
+value with quotes, especially if the escape character "\\" is used
+in the pattern. See examples below
 
 Relationial entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be

--- a/src/commands/entities/create.ts
+++ b/src/commands/entities/create.ts
@@ -32,7 +32,8 @@ attributes are mandatory and apply to specific entity types only.
 
 Regex entities make use of regular expressions specific to a single
 locale. The --pattern and --locale flags must be set when creating
-an entity of type "regex".
+an entity of type "regex". It is recommended to surround the pattern
+value with quotes, especially if the "\\" is used in the pattern.
 
 Relationial entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be
@@ -59,7 +60,7 @@ explicitly provided.
     '',
     'Create a regex entity',
     '$ mix entities:create -P 1922 --entity-type=regex --name PHONE_NUMBER \\',
-    '  --locale en-US --pattern \\d{10} --sensitive --no-canonicalize \\',
+    '  --locale en-US --pattern "\\d{10}" --sensitive --no-canonicalize \\',
     '  --anaphora-type not-set --data-type digits',
     '',
     'Create a relational entity',

--- a/src/commands/entities/create.ts
+++ b/src/commands/entities/create.ts
@@ -34,7 +34,7 @@ Regex entities make use of regular expressions specific to a single
 locale. The --pattern and --locale flags must be set when creating
 an entity of type "regex". It is recommended to surround the pattern
 value with quotes, especially if the escape character "\\" is used
-in the pattern. See examples below
+in the pattern. See examples below.
 
 Relationial entities can have zero or one isA relation and
 zero or many hasA relations. One --is-A or --has-A flag must be


### PR DESCRIPTION
I realized that it's easy to get "\\" swallowed by the command line if not quoted, which messes up pattern values for regular expressions. I added a warning and and fixed the relevant examples in entites:configure, entities:convert and entities:create.