### PR TITLE
fix: Handle empty/white space project and channel names

### DIFF
--- a/src/commands/channels/create.ts
+++ b/src/commands/channels/create.ts
@@ -83,7 +83,7 @@ the command currently requires that both the
   tryDomainOptionsValidation(options: any, domainOptions: DomainOption[]) {
     super.tryDomainOptionsValidation(options, domainOptions)
 
-    validateChannelName(options.name, '--name')
+    validateChannelName(options.name, 'name')
 
     if (options.color !== undefined) {
       validateChannelColor(options.color)

--- a/src/commands/channels/create.ts
+++ b/src/commands/channels/create.ts
@@ -83,7 +83,7 @@ the command currently requires that both the
   tryDomainOptionsValidation(options: any, domainOptions: DomainOption[]) {
     super.tryDomainOptionsValidation(options, domainOptions)
 
-    validateChannelName(options.name)
+    validateChannelName(options.name, '--name')
 
     if (options.color !== undefined) {
       validateChannelColor(options.color)

--- a/src/commands/channels/rename.ts
+++ b/src/commands/channels/rename.ts
@@ -51,7 +51,7 @@ Use this command to change the name of a channel in a project.`
   tryDomainOptionsValidation(options: any, domainOptions: DomainOption[]) {
     super.tryDomainOptionsValidation(options, domainOptions)
 
-    validateChannelName(options['new-name'], '--new-name')
+    validateChannelName(options['new-name'], 'new-name')
   }
 
   async buildRequestParameters(options: Partial<Output>): Promise<ChannelsRenameParams> {

--- a/src/commands/channels/rename.ts
+++ b/src/commands/channels/rename.ts
@@ -51,7 +51,7 @@ Use this command to change the name of a channel in a project.`
   tryDomainOptionsValidation(options: any, domainOptions: DomainOption[]) {
     super.tryDomainOptionsValidation(options, domainOptions)
 
-    validateChannelName(options['new-name'])
+    validateChannelName(options['new-name'], '--new-name')
   }
 
   async buildRequestParameters(options: Partial<Output>): Promise<ChannelsRenameParams> {

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -154,7 +154,7 @@ provide a description of your project using the --description flag.`
     this.validateChannelsAndModes(channels, modes)
 
     for (const channel of channels) {
-      validateChannelName(channel, '-' + (MixFlags.channelMultipleFlag.char?.toString() || 'flag'))
+      validateChannelName(channel, MixFlags.channelMultipleFlag.char?.toString() || 'flag')
     }
 
     const {

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -13,7 +13,7 @@ import makeDebug from 'debug'
 import * as MixFlags from '../../utils/flags'
 import * as ProjectsAPI from '../../mix/api/projects'
 import {asArray} from '../../utils/as-array'
-import {DomainOption} from '../../utils/validations'
+import {DomainOption, validateChannelName} from '../../utils/validations'
 import {MixClient, MixResponse, MixResult, ProjectsCreateParams} from '../../mix/types'
 import MixCommand from '../../utils/base/mix-command'
 import {pluralize as s} from '../../utils/format'
@@ -87,7 +87,7 @@ provide a description of your project using the --description flag.`
 
   get domainOptions(): DomainOption[] {
     debug('get domainOptions()')
-    return ['locale[]', 'organization']
+    return ['locale[]', 'name', 'organization']
   }
 
   async buildRequestParameters(options: Partial<flags.Output>): Promise<ProjectsCreateParams> {
@@ -152,6 +152,10 @@ provide a description of your project using the --description flag.`
     const channels = asArray(options.channel)
     const modes = asArray(options.modes)
     this.validateChannelsAndModes(channels, modes)
+
+    for (const channel of channels) {
+      validateChannelName(channel, '-' + (MixFlags.channelMultipleFlag.char?.toString() || 'flag'))
+    }
 
     const {
       'child-data-compliant': isChildDataCompliant,

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -132,7 +132,7 @@ export function validateChannelName(name: string, optionName: string) {
   debug('validateChannelName()')
   if (name.trim().length === 0) {
     throw (eInvalidValue("Channel name can't be empty or consist only of whitespace.", [
-      `Supply a non-empty value to ${optionName} flag`,
+      `Supply a non-empty value to flag '${optionName}`,
     ]))
   }
 }

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -29,6 +29,7 @@ export type DomainOption =
   | 'locale'
   | 'locale[]'
   | 'mix-app'
+  | 'name'
   | 'offset'
   | 'organization'
   | 'project'
@@ -70,6 +71,8 @@ const validationSchemes = {
     message: `Expected each locale in flag 'locale' to match ${localeRegEx}`}).array(),
   'mix-app': z.number().positive({
     message: "Expected flag 'mix-app' to have a value greater than 0"}),
+  name: z.string().min(1, {
+    message: "Project name can't be empty or consist only of whitespace"}),
   offset: z.number().nonnegative({
     message: "Expected flag 'offset' to have a value greater than or equal to 0"}),
   organization: z.number().positive({
@@ -125,11 +128,11 @@ export function validateChannelColor(color: string): void {
   }
 }
 
-export function validateChannelName(name: string) {
+export function validateChannelName(name: string, optionName: string) {
   debug('validateChannelName()')
   if (name.trim().length === 0) {
     throw (eInvalidValue("Channel name can't be empty or consist only of whitespace.", [
-      'Supply a non-empty value to --name flag',
+      `Supply a non-empty value to ${optionName} flag`,
     ]))
   }
 }

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -132,7 +132,7 @@ export function validateChannelName(name: string, optionName: string) {
   debug('validateChannelName()')
   if (name.trim().length === 0) {
     throw (eInvalidValue("Channel name can't be empty or consist only of whitespace.", [
-      `Supply a non-empty value to flag '${optionName}`,
+      `Supply a non-empty value to flag '${optionName}'`,
     ]))
   }
 }


### PR DESCRIPTION
Handle empty/white space project names and channels