### PR TITLE
fix: refreshed token when watching job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.2.1](https://github.com/nuance-communications/mix-cli/compare/v2.2.0...v2.2.1) (2022-11-08)
+
+
+### Bug Fixes
+
+* builds-export default file path ([#109](https://github.com/nuance-communications/mix-cli/issues/109)) ([7070765](https://github.com/nuance-communications/mix-cli/commit/7070765e4a5e652b8c1931b62d5e597c7c8ee730))
+
 # [2.2.0](https://github.com/nuance-communications/mix-cli/compare/v2.1.0...v2.2.0) (2022-11-08)
 
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ EXAMPLES
   $ mix app-configs:create -M 233 -D 32 -T AC_20211028 -P 1922 --use-project-data-hosts
 ```
 
-_See code: [src/commands/app-configs/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/create.ts)_
+_See code: [src/commands/app-configs/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/create.ts)_
 
 ## `mix app-configs:deploy`
 
@@ -304,7 +304,7 @@ EXAMPLES
   $ mix app-configs:deploy -C 88 --env-geo 233
 ```
 
-_See code: [src/commands/app-configs/deploy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/deploy.ts)_
+_See code: [src/commands/app-configs/deploy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/deploy.ts)_
 
 ## `mix app-configs:destroy`
 
@@ -326,7 +326,7 @@ DESCRIPTION
   ID when prompted. It can also be pre-confirmed by using the --confirm flag.
 ```
 
-_See code: [src/commands/app-configs/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/destroy.ts)_
+_See code: [src/commands/app-configs/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/destroy.ts)_
 
 ## `mix app-configs:export`
 
@@ -355,7 +355,7 @@ EXAMPLES
   $ mix app-configs:export -C 2269 -R NMDPTRIAL_alex_smith_company_com_20190919T190532 --overwrite
 ```
 
-_See code: [src/commands/app-configs/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/export.ts)_
+_See code: [src/commands/app-configs/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/export.ts)_
 
 ## `mix app-configs:get`
 
@@ -386,7 +386,7 @@ EXAMPLE
   $ mix app-configs:get -C 3404
 ```
 
-_See code: [src/commands/app-configs/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/get.ts)_
+_See code: [src/commands/app-configs/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/get.ts)_
 
 ## `mix app-configs:list`
 
@@ -421,7 +421,7 @@ EXAMPLE
   $ mix app-configs:list -M 164 --with-runtime-app NMDPTRIAL_alex_smith_company_com_20190919T190532
 ```
 
-_See code: [src/commands/app-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/list.ts)_
+_See code: [src/commands/app-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/list.ts)_
 
 ## `mix app-configs:undeploy`
 
@@ -451,7 +451,7 @@ EXAMPLES
   $ mix app-configs:undeploy -C 88 --env-geo 233
 ```
 
-_See code: [src/commands/app-configs/undeploy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/undeploy.ts)_
+_See code: [src/commands/app-configs/undeploy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/undeploy.ts)_
 
 ## `mix app-configs:upgrade`
 
@@ -479,7 +479,7 @@ EXAMPLES
   $ mix app-configs:upgrade -C 334 --use-project-data-hosts
 ```
 
-_See code: [src/commands/app-configs/upgrade.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-configs/upgrade.ts)_
+_See code: [src/commands/app-configs/upgrade.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-configs/upgrade.ts)_
 
 ## `mix app-credentials:list`
 
@@ -509,7 +509,7 @@ EXAMPLES
   $ mix app-credentials:list -M 22 --with-geo-name "Production US"
 ```
 
-_See code: [src/commands/app-credentials/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/app-credentials/list.ts)_
+_See code: [src/commands/app-credentials/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/app-credentials/list.ts)_
 
 ## `mix applications:list`
 
@@ -541,7 +541,7 @@ EXAMPLE
   $ mix applications:list -O 64
 ```
 
-_See code: [src/commands/applications/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/applications/list.ts)_
+_See code: [src/commands/applications/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/applications/list.ts)_
 
 ## `mix auth`
 
@@ -562,7 +562,7 @@ EXAMPLE
   mix auth
 ```
 
-_See code: [src/commands/auth.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/auth.ts)_
+_See code: [src/commands/auth.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/auth.ts)_
 
 ## `mix autocomplete [SHELL]`
 
@@ -624,7 +624,7 @@ EXAMPLE
   $ mix bot-configs:list -B 164 --with-runtime-app NMDPTRIAL_alex_smith_company_com_20190919T190532
 ```
 
-_See code: [src/commands/bot-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/bot-configs/list.ts)_
+_See code: [src/commands/bot-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/bot-configs/list.ts)_
 
 ## `mix bot-credentials:list`
 
@@ -659,7 +659,7 @@ EXAMPLES
   $ mix bot-credentials:list -B 12 --with-geo-name "Production US"
 ```
 
-_See code: [src/commands/bot-credentials/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/bot-credentials/list.ts)_
+_See code: [src/commands/bot-credentials/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/bot-credentials/list.ts)_
 
 ## `mix bot-interfaces:export`
 
@@ -689,7 +689,7 @@ EXAMPLES
   $ mix bot-interfaces:export -B 32 -C 54
 ```
 
-_See code: [src/commands/bot-interfaces/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/bot-interfaces/export.ts)_
+_See code: [src/commands/bot-interfaces/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/bot-interfaces/export.ts)_
 
 ## `mix bot-interfaces:get`
 
@@ -719,7 +719,7 @@ EXAMPLES
   $ mix bot-interfaces:get -B 32 -C 54
 ```
 
-_See code: [src/commands/bot-interfaces/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/bot-interfaces/get.ts)_
+_See code: [src/commands/bot-interfaces/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/bot-interfaces/get.ts)_
 
 ## `mix bots:list`
 
@@ -750,7 +750,7 @@ EXAMPLE
   $ mix bots:list -O 64
 ```
 
-_See code: [src/commands/bots/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/bots/list.ts)_
+_See code: [src/commands/bots/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/bots/list.ts)_
 
 ## `mix builds:destroy`
 
@@ -788,7 +788,7 @@ EXAMPLES
   $ mix builds:destroy --build-label ASR_1922_11 --confirm ASR_1922_11
 ```
 
-_See code: [src/commands/builds/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/builds/destroy.ts)_
+_See code: [src/commands/builds/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/builds/destroy.ts)_
 
 ## `mix builds:export`
 
@@ -821,7 +821,7 @@ EXAMPLES
   $ mix builds:export -P 29050 --build-type asr --build-version 11 --overwrite
 ```
 
-_See code: [src/commands/builds/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/builds/export.ts)_
+_See code: [src/commands/builds/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/builds/export.ts)_
 
 ## `mix builds:get`
 
@@ -851,7 +851,7 @@ EXAMPLE
   mix builds:get -P 1922 --build-type nlu --build-version 1
 ```
 
-_See code: [src/commands/builds/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/builds/get.ts)_
+_See code: [src/commands/builds/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/builds/get.ts)_
 
 ## `mix builds:latest`
 
@@ -880,7 +880,7 @@ EXAMPLES
   $ mix builds:latest -P 1922
 ```
 
-_See code: [src/commands/builds/latest.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/builds/latest.ts)_
+_See code: [src/commands/builds/latest.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/builds/latest.ts)_
 
 ## `mix builds:list`
 
@@ -911,7 +911,7 @@ EXAMPLE
   mix builds:list -P 1922 --build-type nlu
 ```
 
-_See code: [src/commands/builds/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/builds/list.ts)_
+_See code: [src/commands/builds/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/builds/list.ts)_
 
 ## `mix channels:activate`
 
@@ -935,7 +935,7 @@ EXAMPLES
     --channel bc40667c-e0f6-11ec-9d64-0242ac120003
 ```
 
-_See code: [src/commands/channels/activate.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/channels/activate.ts)_
+_See code: [src/commands/channels/activate.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/channels/activate.ts)_
 
 ## `mix channels:configure`
 
@@ -992,7 +992,7 @@ EXAMPLES
     --color SALMON
 ```
 
-_See code: [src/commands/channels/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/channels/configure.ts)_
+_See code: [src/commands/channels/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/channels/configure.ts)_
 
 ## `mix channels:create`
 
@@ -1051,7 +1051,7 @@ EXAMPLE
       --mode tts --mode interactivity --color light-pink
 ```
 
-_See code: [src/commands/channels/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/channels/create.ts)_
+_See code: [src/commands/channels/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/channels/create.ts)_
 
 ## `mix channels:deactivate`
 
@@ -1077,7 +1077,7 @@ EXAMPLES
     --confirm bc40667c-e0f6-11ec-9d64-0242ac120003
 ```
 
-_See code: [src/commands/channels/deactivate.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/channels/deactivate.ts)_
+_See code: [src/commands/channels/deactivate.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/channels/deactivate.ts)_
 
 ## `mix channels:rename`
 
@@ -1103,7 +1103,7 @@ EXAMPLES
     --new-name "voice channel"
 ```
 
-_See code: [src/commands/channels/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/channels/rename.ts)_
+_See code: [src/commands/channels/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/channels/rename.ts)_
 
 ## `mix data-hosts:latest`
 
@@ -1134,7 +1134,7 @@ EXAMPLE
   mix data-hosts:latest -D 658 -M 34 -P 619090
 ```
 
-_See code: [src/commands/data-hosts/latest.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/data-hosts/latest.ts)_
+_See code: [src/commands/data-hosts/latest.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/data-hosts/latest.ts)_
 
 ## `mix data-hosts:list`
 
@@ -1169,7 +1169,7 @@ EXAMPLE
   mix data-hosts:list -D 66 -M 62 -P 14990 --build-version 1
 ```
 
-_See code: [src/commands/data-hosts/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/data-hosts/list.ts)_
+_See code: [src/commands/data-hosts/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/data-hosts/list.ts)_
 
 ## `mix data-types:list`
 
@@ -1190,7 +1190,7 @@ EXAMPLE
   mix data-types:list
 ```
 
-_See code: [src/commands/data-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/data-types/list.ts)_
+_See code: [src/commands/data-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/data-types/list.ts)_
 
 ## `mix deployment-flows:list`
 
@@ -1219,7 +1219,7 @@ EXAMPLE
   mix deployment-flows:list -O 64
 ```
 
-_See code: [src/commands/deployment-flows/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/deployment-flows/list.ts)_
+_See code: [src/commands/deployment-flows/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/deployment-flows/list.ts)_
 
 ## `mix engine-packs:list`
 
@@ -1241,7 +1241,7 @@ EXAMPLE
   mix engine-packs:list -O 64
 ```
 
-_See code: [src/commands/engine-packs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/engine-packs/list.ts)_
+_See code: [src/commands/engine-packs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/engine-packs/list.ts)_
 
 ## `mix entities:configure`
 
@@ -1366,7 +1366,7 @@ EXAMPLES
     --sensitive --no-canonicalize --anaphora-type not-set --data-type not-set
 ```
 
-_See code: [src/commands/entities/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/configure.ts)_
+_See code: [src/commands/entities/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/configure.ts)_
 
 ## `mix entities:convert`
 
@@ -1429,7 +1429,7 @@ EXAMPLES
   $ mix entities:convert -P 1922 -E MY_ENTITY --to-entity-type rule-based
 ```
 
-_See code: [src/commands/entities/convert.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/convert.ts)_
+_See code: [src/commands/entities/convert.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/convert.ts)_
 
 ## `mix entities:create`
 
@@ -1557,7 +1557,7 @@ EXAMPLES
     --sensitive --no-canonicalize --anaphora-type not-set --data-type not-set
 ```
 
-_See code: [src/commands/entities/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/create.ts)_
+_See code: [src/commands/entities/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/create.ts)_
 
 ## `mix entities:destroy`
 
@@ -1581,7 +1581,7 @@ EXAMPLE
   $ mix entities:destroy -P 1922 -E CoffeeSize
 ```
 
-_See code: [src/commands/entities/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/destroy.ts)_
+_See code: [src/commands/entities/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/destroy.ts)_
 
 ## `mix entities:get`
 
@@ -1615,7 +1615,7 @@ EXAMPLE
   mix entities:get -P 1922 -E DrinkSize
 ```
 
-_See code: [src/commands/entities/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/get.ts)_
+_See code: [src/commands/entities/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/get.ts)_
 
 ## `mix entities:list`
 
@@ -1654,7 +1654,7 @@ EXAMPLES
   $ mix entities:list -P 1922 --with-entity-type list
 ```
 
-_See code: [src/commands/entities/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/list.ts)_
+_See code: [src/commands/entities/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/list.ts)_
 
 ## `mix entities:rename`
 
@@ -1678,7 +1678,7 @@ EXAMPLE
   $ mix entities:rename -P 1922 -E DrinkSize --new-name DrinkFormat
 ```
 
-_See code: [src/commands/entities/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entities/rename.ts)_
+_See code: [src/commands/entities/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entities/rename.ts)_
 
 ## `mix entity-types:list`
 
@@ -1699,7 +1699,7 @@ EXAMPLE
   mix entity-types:list
 ```
 
-_See code: [src/commands/entity-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/entity-types/list.ts)_
+_See code: [src/commands/entity-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/entity-types/list.ts)_
 
 ## `mix environments:list`
 
@@ -1729,7 +1729,7 @@ EXAMPLE
   mix environments:list -O 64
 ```
 
-_See code: [src/commands/environments/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/environments/list.ts)_
+_See code: [src/commands/environments/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/environments/list.ts)_
 
 ## `mix geographies:list`
 
@@ -1758,7 +1758,7 @@ EXAMPLE
   mix geographies:list
 ```
 
-_See code: [src/commands/geographies/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/geographies/list.ts)_
+_See code: [src/commands/geographies/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/geographies/list.ts)_
 
 ## `mix grammars:export`
 
@@ -1784,7 +1784,7 @@ EXAMPLES
   $ mix grammars:export -P 29050 -E DrinkSize --overwrite
 ```
 
-_See code: [src/commands/grammars/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/grammars/export.ts)_
+_See code: [src/commands/grammars/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/grammars/export.ts)_
 
 ## `mix grammars:replace`
 
@@ -1817,7 +1817,7 @@ EXAMPLES
   $ mix grammars:replace -P 29050 -E DrinkSize -f 29050_DrinkSize.zip -c DrinkSize
 ```
 
-_See code: [src/commands/grammars/replace.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/grammars/replace.ts)_
+_See code: [src/commands/grammars/replace.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/grammars/replace.ts)_
 
 ## `mix help [COMMAND]`
 
@@ -1852,7 +1852,7 @@ EXAMPLE
   mix init
 ```
 
-_See code: [src/commands/init.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/init.ts)_
 
 ## `mix intents:create`
 
@@ -1875,7 +1875,7 @@ EXAMPLE
   $ mix intents:create -P 1922 --name ORDER_DRINK
 ```
 
-_See code: [src/commands/intents/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/intents/create.ts)_
+_See code: [src/commands/intents/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/intents/create.ts)_
 
 ## `mix intents:destroy`
 
@@ -1899,7 +1899,7 @@ EXAMPLE
   $ mix intents:destroy -P 1922 -I ORDER_DRINK
 ```
 
-_See code: [src/commands/intents/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/intents/destroy.ts)_
+_See code: [src/commands/intents/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/intents/destroy.ts)_
 
 ## `mix intents:get`
 
@@ -1925,7 +1925,7 @@ EXAMPLE
   $ mix intents:get -P 1922 -I ORDER_DRINK
 ```
 
-_See code: [src/commands/intents/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/intents/get.ts)_
+_See code: [src/commands/intents/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/intents/get.ts)_
 
 ## `mix intents:list`
 
@@ -1953,7 +1953,7 @@ EXAMPLE
   $ mix intents:list -P 1922
 ```
 
-_See code: [src/commands/intents/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/intents/list.ts)_
+_See code: [src/commands/intents/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/intents/list.ts)_
 
 ## `mix intents:rename`
 
@@ -1977,7 +1977,7 @@ EXAMPLE
   $ mix intents:rename -P 1922 -I ORDER_DRINK --new-name ORDER_COFFEE
 ```
 
-_See code: [src/commands/intents/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/intents/rename.ts)_
+_See code: [src/commands/intents/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/intents/rename.ts)_
 
 ## `mix jobs:cancel`
 
@@ -2003,7 +2003,7 @@ EXAMPLE
   mix jobs:cancel -P 1922 -J 15d4d4ce-7cc3-45f6-ab38-aad326e6fc20
 ```
 
-_See code: [src/commands/jobs/cancel.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/jobs/cancel.ts)_
+_See code: [src/commands/jobs/cancel.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/jobs/cancel.ts)_
 
 ## `mix jobs:get`
 
@@ -2031,7 +2031,7 @@ EXAMPLE
   mix jobs:get -P 1922 -J 25a08872-c635-43f1-b459-5bd98a1c2576
 ```
 
-_See code: [src/commands/jobs/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/jobs/get.ts)_
+_See code: [src/commands/jobs/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/jobs/get.ts)_
 
 ## `mix jobs:list`
 
@@ -2061,7 +2061,7 @@ EXAMPLE
   mix jobs:list -P 1922
 ```
 
-_See code: [src/commands/jobs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/jobs/list.ts)_
+_See code: [src/commands/jobs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/jobs/list.ts)_
 
 ## `mix language-topics:list`
 
@@ -2088,7 +2088,7 @@ EXAMPLE
   mix language-topics:list -O 64
 ```
 
-_See code: [src/commands/language-topics/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/language-topics/list.ts)_
+_See code: [src/commands/language-topics/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/language-topics/list.ts)_
 
 ## `mix literals:export`
 
@@ -2116,7 +2116,7 @@ EXAMPLE
   $ mix literals:export -P 29050 -E DrinkSize -L en-US --overwrite
 ```
 
-_See code: [src/commands/literals/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/literals/export.ts)_
+_See code: [src/commands/literals/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/literals/export.ts)_
 
 ## `mix literals:import`
 
@@ -2159,7 +2159,7 @@ EXAMPLES
   $ mix literals:import -P 29050 -E DrinkSize -L en-US -f literals.trsx -c DrinkSize --replace
 ```
 
-_See code: [src/commands/literals/import.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/literals/import.ts)_
+_See code: [src/commands/literals/import.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/literals/import.ts)_
 
 ## `mix locks:get`
 
@@ -2183,7 +2183,7 @@ EXAMPLES
   $ mix locks:get -P 1922"
 ```
 
-_See code: [src/commands/locks/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/locks/get.ts)_
+_See code: [src/commands/locks/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/locks/get.ts)_
 
 ## `mix locks:list`
 
@@ -2220,7 +2220,7 @@ EXAMPLES
   $ mix locks:list -P 249 -U 32
 ```
 
-_See code: [src/commands/locks/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/locks/list.ts)_
+_See code: [src/commands/locks/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/locks/list.ts)_
 
 ## `mix ontology:export`
 
@@ -2246,7 +2246,7 @@ EXAMPLE
   $ mix ontology:export -P 29050 -L en-US --overwrite
 ```
 
-_See code: [src/commands/ontology/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/ontology/export.ts)_
+_See code: [src/commands/ontology/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/ontology/export.ts)_
 
 ## `mix ontology:import`
 
@@ -2278,7 +2278,7 @@ EXAMPLES
   $ mix ontology:import -P 29050 -f ontology.zip -c 29050
 ```
 
-_See code: [src/commands/ontology/import.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/ontology/import.ts)_
+_See code: [src/commands/ontology/import.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/ontology/import.ts)_
 
 ## `mix organizations:list`
 
@@ -2310,7 +2310,7 @@ EXAMPLE
   mix organizations:list
 ```
 
-_See code: [src/commands/organizations/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/organizations/list.ts)_
+_See code: [src/commands/organizations/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/organizations/list.ts)_
 
 ## `mix projects:build`
 
@@ -2338,7 +2338,7 @@ EXAMPLES
   build"
 ```
 
-_See code: [src/commands/projects/build.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/build.ts)_
+_See code: [src/commands/projects/build.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/build.ts)_
 
 ## `mix projects:configure`
 
@@ -2366,7 +2366,7 @@ EXAMPLE
   $ mix projects:configure -P 1922 --data-pack en-US@4.7.0
 ```
 
-_See code: [src/commands/projects/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/configure.ts)_
+_See code: [src/commands/projects/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/configure.ts)_
 
 ## `mix projects:create`
 
@@ -2433,7 +2433,7 @@ EXAMPLES
     -n "ACME Project" --engine-pack 995f6e23-07ff-4f89-9e42-97d0398da7fc
 ```
 
-_See code: [src/commands/projects/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/create.ts)_
+_See code: [src/commands/projects/create.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/create.ts)_
 
 ## `mix projects:destroy`
 
@@ -2465,7 +2465,7 @@ EXAMPLES
   $ mix projects:destroy -P 1922 -c 1922
 ```
 
-_See code: [src/commands/projects/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/destroy.ts)_
+_See code: [src/commands/projects/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/destroy.ts)_
 
 ## `mix projects:export`
 
@@ -2500,7 +2500,7 @@ EXAMPLES
   $ mix projects:export -P 29050 --metadata-only --overwrite
 ```
 
-_See code: [src/commands/projects/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/export.ts)_
+_See code: [src/commands/projects/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/export.ts)_
 
 ## `mix projects:get`
 
@@ -2531,7 +2531,7 @@ EXAMPLE
   mix projects:get -P 1922
 ```
 
-_See code: [src/commands/projects/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/get.ts)_
+_See code: [src/commands/projects/get.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/get.ts)_
 
 ## `mix projects:list`
 
@@ -2559,7 +2559,7 @@ EXAMPLE
   mix projects:list -O 64
 ```
 
-_See code: [src/commands/projects/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/list.ts)_
+_See code: [src/commands/projects/list.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/list.ts)_
 
 ## `mix projects:lock`
 
@@ -2584,7 +2584,7 @@ EXAMPLES
   $ mix projects:lock -P 1922 --notes="Project lock notes"
 ```
 
-_See code: [src/commands/projects/lock.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/lock.ts)_
+_See code: [src/commands/projects/lock.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/lock.ts)_
 
 ## `mix projects:rename`
 
@@ -2607,7 +2607,7 @@ EXAMPLE
   $ mix projects:rename -P 1922 --new-name ACME
 ```
 
-_See code: [src/commands/projects/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/rename.ts)_
+_See code: [src/commands/projects/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/rename.ts)_
 
 ## `mix projects:replace`
 
@@ -2644,7 +2644,7 @@ EXAMPLES
   $ mix projects:replace -P 29050 -f myProject.zip -c 29050
 ```
 
-_See code: [src/commands/projects/replace.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/replace.ts)_
+_See code: [src/commands/projects/replace.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/replace.ts)_
 
 ## `mix projects:unlock`
 
@@ -2666,7 +2666,7 @@ EXAMPLES
   $ mix projects:unlock -P 1922"
 ```
 
-_See code: [src/commands/projects/unlock.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/projects/unlock.ts)_
+_See code: [src/commands/projects/unlock.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/projects/unlock.ts)_
 
 ## `mix samples:export`
 
@@ -2690,7 +2690,7 @@ EXAMPLE
   $ mix samples:export -P 29050 -I ORDER_DRINK -L en-US --overwrite
 ```
 
-_See code: [src/commands/samples/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/samples/export.ts)_
+_See code: [src/commands/samples/export.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/samples/export.ts)_
 
 ## `mix samples:import`
 
@@ -2734,7 +2734,7 @@ EXAMPLES
   $mix samples:import -P 29050 -I ORDER_DRINK -L en-US -f samples.trsx --replace -c ORDER_DRINK
 ```
 
-_See code: [src/commands/samples/import.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/samples/import.ts)_
+_See code: [src/commands/samples/import.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/samples/import.ts)_
 
 ## `mix system:version`
 
@@ -2759,7 +2759,7 @@ EXAMPLE
   mix system:version
 ```
 
-_See code: [src/commands/system/version.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.0/src/commands/system/version.ts)_
+_See code: [src/commands/system/version.ts](https://github.com/nuance-communications/mix-cli/blob/v2.2.1/src/commands/system/version.ts)_
 <!-- commandsstop -->
 
 .

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -50,6 +50,7 @@ import {saveFile} from '../save-file'
 export type Columns = table.Columns<object>
 
 const DEFAULT_FILEPATH = 'outputfile'
+const WATCH_JOB_WAIT_TIME_MS = 10 * 1000
 
 const debug = makeDebug.debug('mix:base:mix-command')
 
@@ -482,11 +483,12 @@ that configuration file swiftly.`)
   async watchJob(jobId: string, projectId: string) {
     debug('watchJob()')
 
-    await cli.wait(2 * 1000)
+    await cli.wait(WATCH_JOB_WAIT_TIME_MS)
     await this.doAuth()
+    this.client?.setToken(this.accessToken?.access_token)
     const response = await this.doSafeRequest(this.client, {jobId, projectId}, JobsAPI.getJob)
     const result = response as MixResult
-    const resultData: any = result?.data
+    const resultData: any = result?.data ?? {}
     debug('resultData: %O', resultData)
     const {status} = resultData
 

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -514,7 +514,7 @@ that configuration file swiftly.`)
       default:
         // mixFailure, connectionFailure and unexpected states are treated the same
         debug('applying default for status %s', status)
-        cli.action.stop(chalk.red('Failed to retrieve job details'))
+        cli.action.stop(chalk.red('Failed to retrieve job details. Please try again.'))
         this.shouldWatchJob = false
         break
     }


### PR DESCRIPTION
When running the jobs:get command with the --watch flag, mix-cli refreshes the token but does not pass it to the client, resulting on a 401 code returned by the endpoint. The refreshed token passed to the client to fix 401 error.