### PR TITLE
fix: app-configs-get undefined options error

### DIFF
--- a/src/commands/app-configs/get.ts
+++ b/src/commands/app-configs/get.ts
@@ -54,10 +54,6 @@ output is brief.`
     return ['config']
   }
 
-  async captureOptions() {
-    super.captureOptions()
-  }
-
   async buildRequestParameters(options: Partial<FlagOutput>): Promise<AppConfigsGetParams> {
     debug('buildRequestParameters()')
     const {config: configId} = options


### PR DESCRIPTION
Fixed app-configs:get undefined options error while capturing options.