### PR TITLE
fix: exclude node_modules from zip packged for Veracode

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -28,7 +28,7 @@ jobs:
 
         
       - name: Generate scan zip
-        run: zip targetUpload.zip `find ./ -name "*.js" -o -name "*.json" -o -name "*.ts"`
+        run: zip targetUpload.zip `find . -path ./node_modules -prune -o -name "*.js" -o -name "*.json" -o -name "*.ts"`
           
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.1


### PR DESCRIPTION
I have updated the set of files included in the zip sent to Veracode for scanning. I am excluding the node_modules directory as it puts unnecessary burden on Veracode and leads to long scan times. Veracode does recommend to exclude node_modules as well.