### PR TITLE
fix: correct help for subcommands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
-        "@oclif/core": "1.23.2",
+        "@oclif/core": "^1.24.3",
         "@oclif/plugin-autocomplete": "^1.3.0",
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^2.1.12",
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.23.2.tgz",
-      "integrity": "sha512-NdaOaUDTRc6g1yTkOAKiEVOiQhc5CNcWNXa0QF4IS4yTjNqp4DOzgtF9Dwe585nPEKzSbTBiz1wyLOa4qIHSRQ==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.26.2.tgz",
+      "integrity": "sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==",
       "dependencies": {
         "@oclif/linewrap": "^1.0.0",
         "@oclif/screen": "^3.0.4",
@@ -19338,9 +19338,9 @@
       }
     },
     "@oclif/core": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.23.2.tgz",
-      "integrity": "sha512-NdaOaUDTRc6g1yTkOAKiEVOiQhc5CNcWNXa0QF4IS4yTjNqp4DOzgtF9Dwe585nPEKzSbTBiz1wyLOa4qIHSRQ==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.26.2.tgz",
+      "integrity": "sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==",
       "requires": {
         "@oclif/linewrap": "^1.0.0",
         "@oclif/screen": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "bugs": "https://community.mix.nuance.com",
   "dependencies": {
-    "@oclif/core": "1.23.2",
+    "@oclif/core": "^1.24.3",
     "@oclif/plugin-autocomplete": "^1.3.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.1.12",

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -1,0 +1,35 @@
+
+import {expect, test} from '@oclif/test'
+
+describe('Help message handling', () => {
+  test
+    .stdout()
+    .command(['help'])
+  .it('works for global Mix', (ctx)=>{
+    expect(ctx.stdout).to.include('projects')
+    expect(ctx.stdout).to.include('manage projects')
+    expect(ctx.stdout).to.include('auth')
+    expect(ctx.stdout).to.include('obtain Mix access token')
+  })
+
+  // we use the help subcommand instead of passing in --help to the projects:list command
+  // this is to workaround the weird behavior of oclif where it will not accept --help
+  // during testing, even though it works fine when running the command normally
+  test
+    .stdout()
+    .command(['help', 'projects:list'])
+  .it('works for projects:list', (ctx)=>{
+    expect(ctx.stdout).to.include('--json')
+    expect(ctx.stdout).to.include('list projects')
+    expect(ctx.stdout).to.include('exclude project channels from the list')
+  })
+
+  test
+    .stdout()
+    .command(['help', 'projects'])
+  .it('works for projects', (ctx)=>{
+    expect(ctx.stdout).to.include('manage projects')
+    expect(ctx.stdout).to.include('projects:list')
+    expect(ctx.stdout).to.include('list projects')
+  })
+})

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -18,7 +18,7 @@ describe('Help message handling', () => {
   test
     .stdout()
     .command(['help', 'projects:list'])
-  .it('provides help for a specific subcommand', (ctx)=>{
+  .it('provides help for a specific command', (ctx)=>{
     expect(ctx.stdout).to.include('--json')
     expect(ctx.stdout).to.include('list projects')
     expect(ctx.stdout).to.include('exclude project channels from the list')
@@ -27,7 +27,7 @@ describe('Help message handling', () => {
   test
     .stdout()
     .command(['help', 'projects'])
-  .it('provides help for a specific command', (ctx)=>{
+  .it('provides help for a specific topic', (ctx)=>{
     expect(ctx.stdout).to.include('manage projects')
     expect(ctx.stdout).to.include('projects:list')
     expect(ctx.stdout).to.include('list projects')

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -5,7 +5,7 @@ describe('Help message handling', () => {
   test
     .stdout()
     .command(['help'])
-  .it('works for global Mix', (ctx)=>{
+  .it('provides global help', (ctx)=>{
     expect(ctx.stdout).to.include('projects')
     expect(ctx.stdout).to.include('manage projects')
     expect(ctx.stdout).to.include('auth')
@@ -18,7 +18,7 @@ describe('Help message handling', () => {
   test
     .stdout()
     .command(['help', 'projects:list'])
-  .it('works for projects:list', (ctx)=>{
+  .it('provides help for a specific subcommand', (ctx)=>{
     expect(ctx.stdout).to.include('--json')
     expect(ctx.stdout).to.include('list projects')
     expect(ctx.stdout).to.include('exclude project channels from the list')
@@ -27,7 +27,7 @@ describe('Help message handling', () => {
   test
     .stdout()
     .command(['help', 'projects'])
-  .it('works for projects', (ctx)=>{
+  .it('provides help for a specific command', (ctx)=>{
     expect(ctx.stdout).to.include('manage projects')
     expect(ctx.stdout).to.include('projects:list')
     expect(ctx.stdout).to.include('list projects')


### PR DESCRIPTION
Resolves #171 

Have tested it out using the two tar files generated by `npm pack`. The one generated on `main` gives the TypeError. The one generated on this branch doesn't have that error.