### PR TITLE
fix: add warning on redeploy instead of error

### DIFF
--- a/src/commands/app-configs/deploy.ts
+++ b/src/commands/app-configs/deploy.ts
@@ -14,6 +14,9 @@ import * as MixFlags from '../../utils/flags'
 import MixCommand from '../../utils/base/mix-command'
 import {AppConfigsDeployParams, MixClient, MixResponse, MixResult} from '../../mix/types'
 import {DomainOption} from '../../utils/validations'
+import {MixError} from '../../mix/types'
+import {CliUx} from '@oclif/core'
+import chalk from 'chalk'
 
 const debug = makeDebug('mix:commands:app-configs:deploy')
 
@@ -96,5 +99,18 @@ the application configuration was created.
     debug('transformResponse()')
     const data = result.data as any
     return data.deployments
+  }
+
+  // Show a warning if a user tries to deploy an app-config when it is already deployed
+  handleError(error: MixError) {
+    debug('handleError() error.statusCode: %d', error.statusCode)
+
+    if (error.statusCode === 400 && error.message.toLocaleLowerCase().includes('deployment already completed')) {
+      CliUx.ux.action.stop(chalk.yellow('Aborted'))
+      this.warn(`Application configuration was already deployed. 
+It is not possible to re-deploy an already deployed application configuration.`)
+    } else {
+      super.handleError(error)
+    }
   }
 }

--- a/test/commands/app-configs/deploy.test.ts
+++ b/test/commands/app-configs/deploy.test.ts
@@ -55,11 +55,10 @@ describe('app-configs:deploy', () => {
           .put(endpoint)
           .reply(400, td.deploy.response400)
         )
-    .stdout()
+    .stderr()
     .command(['app-configs:deploy','-C', config])
-    .catch(ctx => {
-      expect(ctx.message).to.contain('Deployment already completed')
-      })
-    .it('fails if app config is already deployed', ctx => {
+    .it('fails if app config is already deployed and shows warning', ctx => {
+      const [firstLine] = ctx.stderr.split('\n')
+      expect(firstLine).to.contain('configuration was already deployed')
     })
 })


### PR DESCRIPTION
This resolves [#155](https://github.com/nuance-communications/mix-cli/issues/155)