### PR TITLE
fix: add failed message on error requests

### DIFF
--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -294,6 +294,7 @@ that configuration file swiftly.`)
   handleError(error: MixError) {
     debug('handleError() error.statusCode: %d', error.statusCode)
 
+    CliUx.ux.action.stop(chalk.red('Failed'))
     switch (error.statusCode) {
       case 400: throw eInvalidValue(error.message)
       case 401: throw eUnauthorized(error.message)


### PR DESCRIPTION
In its current implementation, mix-cli does not stop the "spinner" upon hitting an error with the backend. This leads to a situation where a full error message is given to the user (error message, error code and "try this") followed by a line that says something similar to "Retrieve projects for organization 99999... Done".

That last line is misleading. Explicitly stopping the spinner when the error happens will fix this.

This solves [#182](https://github.com/nuance-communications/mix-cli/issues/182).