### PR TITLE
feat: add support for multiple configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,528 @@ See our [Contribution Guidelines](CONTRIBUTING.md).
 
 # Commands
 <!-- commands -->
+* [`mix app-configs:create`](#mix-app-configscreate)
+* [`mix app-configs:deploy`](#mix-app-configsdeploy)
+* [`mix app-configs:destroy`](#mix-app-configsdestroy)
+* [`mix app-configs:export`](#mix-app-configsexport)
+* [`mix app-configs:get`](#mix-app-configsget)
+* [`mix app-configs:list`](#mix-app-configslist)
+* [`mix app-configs:undeploy`](#mix-app-configsundeploy)
+* [`mix app-configs:upgrade`](#mix-app-configsupgrade)
+* [`mix app-credentials:list`](#mix-app-credentialslist)
+* [`mix applications:get`](#mix-applicationsget)
+* [`mix applications:list`](#mix-applicationslist)
+* [`mix auth`](#mix-auth)
 * [`mix autocomplete [SHELL]`](#mix-autocomplete-shell)
+* [`mix bot-configs:list`](#mix-bot-configslist)
+* [`mix bot-credentials:list`](#mix-bot-credentialslist)
+* [`mix bot-interfaces:export`](#mix-bot-interfacesexport)
+* [`mix bot-interfaces:get`](#mix-bot-interfacesget)
+* [`mix bots:list`](#mix-botslist)
+* [`mix builds:destroy`](#mix-buildsdestroy)
+* [`mix builds:export`](#mix-buildsexport)
+* [`mix builds:get`](#mix-buildsget)
+* [`mix builds:latest`](#mix-buildslatest)
+* [`mix builds:list`](#mix-buildslist)
+* [`mix channels:activate`](#mix-channelsactivate)
+* [`mix channels:configure`](#mix-channelsconfigure)
+* [`mix channels:create`](#mix-channelscreate)
+* [`mix channels:deactivate`](#mix-channelsdeactivate)
+* [`mix channels:rename`](#mix-channelsrename)
+* [`mix data-hosts:latest`](#mix-data-hostslatest)
+* [`mix data-hosts:list`](#mix-data-hostslist)
+* [`mix data-types:list`](#mix-data-typeslist)
+* [`mix deployment-flows:list`](#mix-deployment-flowslist)
+* [`mix engine-packs:list`](#mix-engine-packslist)
+* [`mix entities:configure`](#mix-entitiesconfigure)
+* [`mix entities:convert`](#mix-entitiesconvert)
+* [`mix entities:create`](#mix-entitiescreate)
+* [`mix entities:destroy`](#mix-entitiesdestroy)
+* [`mix entities:get`](#mix-entitiesget)
+* [`mix entities:list`](#mix-entitieslist)
+* [`mix entities:rename`](#mix-entitiesrename)
+* [`mix entity-types:list`](#mix-entity-typeslist)
+* [`mix env-configs:list`](#mix-env-configslist)
+* [`mix environments:list`](#mix-environmentslist)
+* [`mix geographies:list`](#mix-geographieslist)
+* [`mix grammars:export`](#mix-grammarsexport)
+* [`mix grammars:replace`](#mix-grammarsreplace)
 * [`mix help [COMMAND]`](#mix-help-command)
+* [`mix init`](#mix-init)
+* [`mix intents:create`](#mix-intentscreate)
+* [`mix intents:destroy`](#mix-intentsdestroy)
+* [`mix intents:get`](#mix-intentsget)
+* [`mix intents:list`](#mix-intentslist)
+* [`mix intents:rename`](#mix-intentsrename)
+* [`mix jobs:cancel`](#mix-jobscancel)
+* [`mix jobs:get`](#mix-jobsget)
+* [`mix jobs:list`](#mix-jobslist)
+* [`mix language-topics:list`](#mix-language-topicslist)
+* [`mix literals:export`](#mix-literalsexport)
+* [`mix literals:import`](#mix-literalsimport)
+* [`mix locks:get`](#mix-locksget)
+* [`mix locks:list`](#mix-lockslist)
+* [`mix ontology:export`](#mix-ontologyexport)
+* [`mix ontology:import`](#mix-ontologyimport)
+* [`mix organizations:list`](#mix-organizationslist)
+* [`mix projects:build`](#mix-projectsbuild)
+* [`mix projects:configure`](#mix-projectsconfigure)
+* [`mix projects:create`](#mix-projectscreate)
+* [`mix projects:destroy`](#mix-projectsdestroy)
+* [`mix projects:export`](#mix-projectsexport)
+* [`mix projects:get`](#mix-projectsget)
+* [`mix projects:list`](#mix-projectslist)
+* [`mix projects:lock`](#mix-projectslock)
+* [`mix projects:rename`](#mix-projectsrename)
+* [`mix projects:replace`](#mix-projectsreplace)
+* [`mix projects:unlock`](#mix-projectsunlock)
+* [`mix samples:export`](#mix-samplesexport)
+* [`mix samples:import`](#mix-samplesimport)
+* [`mix system:list`](#mix-systemlist)
+* [`mix system:version`](#mix-systemversion)
+* [`mix systems:list`](#mix-systemslist)
+* [`mix voices:list`](#mix-voiceslist)
+
+## `mix app-configs:create`
+
+create an application configuration
+
+```
+USAGE
+  $ mix app-configs:create -D <value> -M <value> -P <value> -T <value> [--json |  | --yaml] [--use-project-data-hosts]
+    [--with-build-type asr|dialog|nlu] [--with-locale <value>]
+
+FLAGS
+  -D, --deployment-flow=<value>  (required) deployment flow ID
+  -M, --mix-app=<value>          (required) Mix application ID
+  -P, --project=<value>          (required) project ID (defaults to MIX_PROJECT)
+  -T, --tag=<value>              (required) context tag
+  --json                         output raw data in JSON format
+  --use-project-data-hosts       use data hosts defined in project
+  --with-build-type=<option>...  build types to include
+                                 <options: asr|dialog|nlu>
+  --with-locale=<value>...       locale code; use format 'aa-AA'
+  --yaml                         output raw data in YAML format
+
+DESCRIPTION
+  create an application configuration
+
+  Use this command to create an application configuration. The Mix Application ID
+  can be looked up using the applications:list command. The deployment flow ID
+  can be retrieved using the deployment-flows:list command. The context tag
+  should be unique.
+
+EXAMPLES
+  Create an application configuration using latest builds from project without data hosts information
+
+  $ mix app-configs:create -M 233 -D 32 -T AC_20211028 -P 1922
+
+
+
+  Create an application configuration using latest builds from project but only for build type ASR
+
+  and locale en-US, without data hosts information
+
+  $ mix app-configs:create -M 233 -D 32 -T AC_20211028 -P 1922 --with-locale en-US --with-build-type asr
+
+
+
+  Create an application configuration using latest builds from project including data hosts defined in project
+
+  $ mix app-configs:create -M 233 -D 32 -T AC_20211028 -P 1922 --use-project-data-hosts
+```
+
+_See code: [src/commands/app-configs/create.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/create.ts)_
+
+## `mix app-configs:deploy`
+
+deploy an application configuration
+
+```
+USAGE
+  $ mix app-configs:deploy -C <value> [--env-geo <value>] [--json |  | --yaml]
+
+FLAGS
+  -C, --config=<value>  (required) application configuration ID
+  --env-geo=<value>...  environment-geography ID
+  --json                output raw data in JSON format
+  --yaml                output raw data in YAML format
+
+DESCRIPTION
+  deploy an application configuration
+
+  Use this command to deploy an application configuration. The configuration ID
+  can be retrieved using the app-configs:list command.
+
+  A specific environment-geography can be specified using the 'env-geo' flag.
+  If none is specified, the application configuration will get deployed to the
+  next environment-geography defined in the deployment flow specified when
+  the application configuration was created.
+
+
+EXAMPLES
+  Deploy an application configuration to the next environment-geography
+
+  $ mix app-configs:deploy -C 88
+
+
+
+  Deploy an application configuration to a specific environment-geography
+
+  $ mix app-configs:deploy -C 88 --env-geo 233
+```
+
+_See code: [src/commands/app-configs/deploy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/deploy.ts)_
+
+## `mix app-configs:destroy`
+
+destroy an application configuration
+
+```
+USAGE
+  $ mix app-configs:destroy -C <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -C, --config=<value>   (required) application configuration ID
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  destroy an application configuration
+
+  Use this command to permanently delete an application configuration.
+  The deletion needs to be confirmed by re-typing the application configuration
+  ID when prompted. It can also be pre-confirmed by using the 'confirm' flag.
+
+EXAMPLES
+  $ mix app-configs:destroy -C 3404
+```
+
+_See code: [src/commands/app-configs/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/destroy.ts)_
+
+## `mix app-configs:export`
+
+export an application configuration
+
+```
+USAGE
+  $ mix app-configs:export -C <value> -R <value> [-f <value>] [--overwrite]
+
+FLAGS
+  -C, --config=<value>       (required) application configuration ID
+  -R, --runtime-app=<value>  (required) fully-qualified runtime application ID
+  -f, --filepath=<value>     output file path (defaults to "app-config-<configid>.zip")
+  --overwrite                overwrite output file if it exists
+
+DESCRIPTION
+  export an application configuration
+
+  Use this command to export an application configuration. The configuration ID
+  can be retrieved using the app-configs:list command. The runtime application ID
+  can be found with the app-credentials:list command.
+
+  The contents of the exported zip file depend on the role you have been granted
+  on the Mix platform.
+
+EXAMPLES
+  Export an application configuration
+
+  $ mix app-configs:export -C 2269 -R NMDPTRIAL_alex_smith_company_com_20190919T190532 --overwrite
+```
+
+_See code: [src/commands/app-configs/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/export.ts)_
+
+## `mix app-configs:get`
+
+get details about an application configuration
+
+```
+USAGE
+  $ mix app-configs:get -C <value> [--columns <value> ] [--filter <value> | [--json | --csv | --yaml] | ]
+    [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+
+FLAGS
+  -C, --config=<value>  (required) application configuration ID
+  --columns=<value>     only show provided columns (comma-separated) (with 'csv' flag only)
+  --csv                 output to csv format
+  --filter=<value>      filter property by partial string matching, ex: name=foo
+  --json                output raw data in JSON format
+  --no-header           hide table header from output
+  --no-truncate         do not truncate output to fit screen
+  --sort=<value>        property to sort by (prepend '-' for descending)
+  --yaml                output raw data in YAML format
+
+DESCRIPTION
+  get details about an application configuration
+
+  Use this command to get details about a particular application configuration.
+  The configuration ID can be retrieved using the app-configs:list command.
+  Use the 'json' or 'yaml' flag to get the full details as the human-readable
+  output is brief.
+
+EXAMPLES
+  $ mix app-configs:get -C 3404
+```
+
+_See code: [src/commands/app-configs/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/get.ts)_
+
+## `mix app-configs:list`
+
+list application configurations for a Mix application
+
+```
+USAGE
+  $ mix app-configs:list -M <value> [--exclude-overrides] [--live-only] [--columns <value> |  | [--json | --csv |
+    --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+    [--with-runtime-app <value>] [--with-tag <value>]
+
+FLAGS
+  -M, --mix-app=<value>       (required) Mix application ID
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --exclude-overrides         exclude application configurations that are overridden
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --json                      output raw data in JSON format
+  --live-only                 include only the application configurations that are currently deployed
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --sort=<value>              property to sort by (prepend '-' for descending)
+  --with-runtime-app=<value>  filter results by fully-qualified runtime app ID
+  --with-tag=<value>          filter results by context tag
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list application configurations for a Mix application
+
+  Use this command to list the application configurations in an organization.
+  The organization ID can be retrieved using the organizations:list command.
+  A number of flags can be used to constrain the returned results. The runtime
+  application IDs can be retrieved using the app-credentials:list command.
+
+EXAMPLES
+  $ mix app-configs:list -M 164 --with-runtime-app NMDPTRIAL_alex_smith_company_com_20190919T190532
+```
+
+_See code: [src/commands/app-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/list.ts)_
+
+## `mix app-configs:undeploy`
+
+undeploy an application configuration
+
+```
+USAGE
+  $ mix app-configs:undeploy -C <value> [--env-geo <value>] [--json |  | --yaml]
+
+FLAGS
+  -C, --config=<value>  (required) application configuration ID
+  --env-geo=<value>...  environment-geography ID
+  --json                output raw data in JSON format
+  --yaml                output raw data in YAML format
+
+DESCRIPTION
+  undeploy an application configuration
+
+  Use this command to undeploy a specific application configuration.
+  The configuration ID can be retrieved using the app-configs:list command.
+  The environment-geographies relevant to an application configuration can be
+  found in the JSON output of the app-configs:get command.
+
+EXAMPLES
+  Undeploy an application configuration to the next environment-geography
+
+  $ mix app-configs:undeploy -C 88
+
+
+
+  Undeploy an application configuration from a specific environment-geography
+
+  $ mix app-configs:undeploy -C 88 --env-geo 233
+```
+
+_See code: [src/commands/app-configs/undeploy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/undeploy.ts)_
+
+## `mix app-configs:upgrade`
+
+update an application configuration to latest build versions
+
+```
+USAGE
+  $ mix app-configs:upgrade -C <value> [--json |  | --yaml] [--use-project-data-hosts]
+
+FLAGS
+  -C, --config=<value>      (required) application configuration ID
+  --json                    output raw data in JSON format
+  --use-project-data-hosts  use data hosts defined in project
+  --yaml                    output raw data in YAML format
+
+DESCRIPTION
+  update an application configuration to latest build versions
+
+  Use this command to upgrade an application configuration to the latest build
+  versions. The configuration ID can be retrieved using the app-configs:list command.
+
+EXAMPLES
+  Upgrade an application configuration using latest builds from project without data hosts information
+
+  $ mix app-configs:upgrade -C 334
+
+
+
+  Upgrade an application configuration using latest builds from project including data hosts defined in project
+
+  $ mix app-configs:upgrade -C 334 --use-project-data-hosts
+```
+
+_See code: [src/commands/app-configs/upgrade.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-configs/upgrade.ts)_
+
+## `mix app-credentials:list`
+
+list application credentials for a Mix application
+
+```
+USAGE
+  $ mix app-credentials:list -M <value> [--with-geo-name <value>] [--full] [--json |  | --yaml]
+
+FLAGS
+  -M, --mix-app=<value>    (required) Mix application ID
+  --full                   show all application credentials details
+  --json                   output raw data in JSON format
+  --with-geo-name=<value>  geography name
+  --yaml                   output raw data in YAML format
+
+DESCRIPTION
+  list application credentials for a Mix application
+
+  Use this command to list the application credentials for a Mix application.
+  This lets you retrieve the runtime application ID that is required in other
+  commands.
+
+EXAMPLES
+  List application credentials for a Mix application
+
+  $ mix app-credentials:list -M 22
+
+
+
+  List application credentials for a Mix application that match a specific environment-geography
+
+  $ mix app-credentials:list -M 22 --with-geo-name "Production US"
+```
+
+_See code: [src/commands/app-credentials/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/app-credentials/list.ts)_
+
+## `mix applications:get`
+
+get details about a Mix application
+
+```
+USAGE
+  $ mix applications:get -M <value> [--columns <value> |  | [--json |  | --yaml] | ] [--filter <value> |  | ]
+    [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+
+FLAGS
+  -M, --mix-app=<value>  (required) Mix application ID
+  --columns=<value>      only show provided columns (comma-separated)
+  --filter=<value>       filter property by partial string matching, ex: name=foo
+  --json                 output raw data in JSON format
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --sort=<value>         property to sort by (prepend '-' for descending)
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  get details about a Mix application
+
+  Use this command to get details about a particular Mix application.
+
+EXAMPLES
+  $ mix applications:get -M 94
+```
+
+_See code: [src/commands/applications/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/applications/get.ts)_
+
+## `mix applications:list`
+
+list Mix applications
+
+```
+USAGE
+  $ mix applications:list [--limit <value>] [--offset <value>] [-O <value>] [--columns <value> |  | [--json | --csv |
+    --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>] [--live-only
+    --full] [--omit-overridden ] [--with-name <value>] [--with-runtime-app <value>]
+
+FLAGS
+  -O, --organization=<value>  organization ID
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --full                      show all application details (permissions allowing)
+  --json                      output raw data in JSON format
+  --limit=<value>             limit maximum results returned (defaults to Mix API behavior)
+  --live-only                 include only the application configurations that are currently deployed
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --offset=<value>            to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --omit-overridden           omit application configurations that are overridden
+  --sort=<value>              property to sort by (prepend '-' for descending)
+  --with-name=<value>         filter results by Mix application name (case-sensitive)
+  --with-runtime-app=<value>  filter results by fully-qualified runtime app ID
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list Mix applications
+
+  Use this command to list Mix applications.
+  A number of flags can be used to constrain the returned results.
+
+EXAMPLES
+  List Mix applications to which you have access, across all organizations
+
+  $ mix applications:list
+
+
+
+  List Mix applications that are part of a particular organization
+
+  $ mix applications:list -O 64
+```
+
+_See code: [src/commands/applications/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/applications/list.ts)_
+
+## `mix auth`
+
+obtain a Mix access token
+
+```
+USAGE
+  $ mix auth [-S <value>]
+
+FLAGS
+  -S, --system=<value>  Mix system
+
+DESCRIPTION
+  obtain a Mix access token
+
+  Use this command to retrieve an access token. Once mix-cli has acquired the
+  access token, it takes care of refreshing it automatically.
+
+  Use the 'system' flag to authenticate with a specific Mix system. mix-cli executes
+  commands against the last Mix system it successfully authenticated with.
+
+  Run the 'system:list' command to see your list of configured Mix systems.
+
+EXAMPLES
+  Authenticate with last Mix system used
+
+  $ mix auth
+
+  Authenticate with and switch to the "us" Mix system
+
+  $ mix auth --system us
+```
+
+_See code: [src/commands/auth.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/auth.ts)_
 
 ## `mix autocomplete [SHELL]`
 
@@ -206,6 +726,1372 @@ EXAMPLES
 
 _See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.3.10/src/commands/autocomplete/index.ts)_
 
+## `mix bot-configs:list`
+
+list application configurations for a bot
+
+```
+USAGE
+  $ mix bot-configs:list -B <value> [--exclude-overrides] [--live-only] [--columns <value> |  | [--json | --csv |
+    --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+    [--with-runtime-app <value>] [--with-tag <value>]
+
+FLAGS
+  -B, --bot=<value>           (required) Bot ID
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --exclude-overrides         exclude application configurations that are overridden
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --json                      output raw data in JSON format
+  --live-only                 include only the application configurations that are currently deployed
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --sort=<value>              property to sort by (prepend '-' for descending)
+  --with-runtime-app=<value>  filter results by fully-qualified runtime app ID
+  --with-tag=<value>          filter results by context tag
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list application configurations for a bot
+
+  Use this command to list the application configurations for a bot.
+  A number of flags can be used to constrain the returned results. The runtime
+  bot IDs can be retrieved using the bot-credentials:list command.
+
+  Bots are used in certain integration scenarios. A bot is a Mix application
+  with configurations that include dialog builds.
+
+  See https://docs.nuance.com/mix/apis/mix-api/v4/reference/bots/ for details.
+
+EXAMPLES
+  $ mix bot-configs:list -B 164 --with-runtime-app NMDPTRIAL_alex_smith_company_com_20190919T190532
+```
+
+_See code: [src/commands/bot-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/bot-configs/list.ts)_
+
+## `mix bot-credentials:list`
+
+list credentials for a bot
+
+```
+USAGE
+  $ mix bot-credentials:list -B <value> [--with-geo-name <value>] [--full] [--json |  | --yaml]
+
+FLAGS
+  -B, --bot=<value>        (required) Bot ID
+  --full                   show all bot credentials details
+  --json                   output raw data in JSON format
+  --with-geo-name=<value>  geography name
+  --yaml                   output raw data in YAML format
+
+DESCRIPTION
+  list credentials for a bot
+
+  Use this command to list the credentials for a bot.
+  This lets you retrieve the runtime application ID that is required
+  in other commands.
+
+  Bots are used in certain integration scenarios. A bot is a Mix application
+  with configurations that include dialog builds.
+
+  See https://docs.nuance.com/mix/apis/mix-api/v4/reference/bots/ for details.
+
+EXAMPLES
+  List bot credentials for a bot
+
+  $ mix bot-credentials:list -B 12
+
+
+
+  List bot credentials for a bot that match a specific environment-geography
+
+  $ mix bot-credentials:list -B 12 --with-geo-name "Production US"
+```
+
+_See code: [src/commands/bot-credentials/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/bot-credentials/list.ts)_
+
+## `mix bot-interfaces:export`
+
+export the interface of a bot
+
+```
+USAGE
+  $ mix bot-interfaces:export -B <value> -C <value> [-f <value>] [--overwrite]
+
+FLAGS
+  -B, --bot=<value>       (required) Bot ID
+  -C, --config=<value>    (required) application configuration ID
+  -f, --filepath=<value>  output file path
+  --overwrite             overwrite output file if it exists
+
+DESCRIPTION
+  export the interface of a bot
+
+  Use this command to export the interface of a bot.
+  The configuration ID can be retrieved using the bot-configs:list command.
+
+  Bots are used in certain integration scenarios. A bot is a Mix application
+  with configurations that include dialog builds.
+
+  See https://docs.nuance.com/mix/apis/mix-api/v4/reference/bots/ for details.
+
+EXAMPLES
+  Export the interface of a bot
+
+  $ mix bot-interfaces:export -B 32 -C 54
+```
+
+_See code: [src/commands/bot-interfaces/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/bot-interfaces/export.ts)_
+
+## `mix bot-interfaces:get`
+
+retrieve the interface of a bot
+
+```
+USAGE
+  $ mix bot-interfaces:get -B <value> -C <value> [--json |  | --yaml]
+
+FLAGS
+  -B, --bot=<value>     (required) Bot ID
+  -C, --config=<value>  (required) application configuration ID
+  --json                output raw data in JSON format
+  --yaml                output raw data in YAML format
+
+DESCRIPTION
+  retrieve the interface of a bot
+
+  Use this command to get the interface of a bot.
+  The configuration ID can be retrieved using the bot-configs:list command.
+
+  Bots are used in certain integration scenarios. A bot is a Mix application
+  with configurations that include dialog builds.
+
+  See https://docs.nuance.com/mix/apis/mix-api/v4/reference/bots/ for details.
+
+EXAMPLES
+  Retrieve the interface of a bot
+
+  $ mix bot-interfaces:get -B 32 -C 54
+```
+
+_See code: [src/commands/bot-interfaces/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/bot-interfaces/get.ts)_
+
+## `mix bots:list`
+
+list bots in an organization
+
+```
+USAGE
+  $ mix bots:list -O <value> [--live-only --full] [--columns <value> |  | [--json | --csv | --yaml] | ]
+    [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>] [--omit-overridden ]
+
+FLAGS
+  -O, --organization=<value>  (required) organization ID
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --full                      show all bot details
+  --json                      output raw data in JSON format
+  --live-only                 include only the application configurations that are currently deployed
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --omit-overridden           omit application configurations that are overridden
+  --sort=<value>              property to sort by (prepend '-' for descending)
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list bots in an organization
+
+  Use this command to list bots for a specific Mix organization.
+  Use flag 'full' to list all bot details, including the list of bot configs.
+  Use flag 'live-only'  with flag 'full' to filter out
+  bot configs that are NOT deployed.
+  Use flag 'omit-overridden'  with flag 'full' to filter out
+  bot configs that are overridden.
+  Flags 'live-only' and 'omit-overridden' cannot be used together.
+  Flags 'live-only' and 'omit-overridden' can only be used with flag 'full'.
+
+EXAMPLES
+  $ mix bots:list -O 64
+```
+
+_See code: [src/commands/bots/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/bots/list.ts)_
+
+## `mix builds:destroy`
+
+destroy a build
+
+```
+USAGE
+  $ mix builds:destroy [--build-label <value> | --build-type asr|dialog|nlu | -P <value> | --build-version <value>]
+    [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>    project ID
+  -c, --confirm=<value>    skip confirmation prompt by pre-supplying value
+  --build-label=<value>    build label (format is <buildType>_<projectId>_<buildVersion>)
+  --build-type=<option>    build type
+                           <options: asr|dialog|nlu>
+  --build-version=<value>  build version
+  --json                   output raw data in JSON format
+  --yaml                   output raw data in YAML format
+
+DESCRIPTION
+  destroy a build
+
+  Use this command to permanently delete a build. The build can be specified
+  using the build label or the combination of project ID, build type and build
+  version.
+
+  The deletion needs to be confirmed by re-typing the build label when prompted.
+  It can also be pre-confirmed by using the 'confirm' flag.
+
+EXAMPLES
+  Destroy a build
+
+  $ mix builds:destroy -P 1922 --build-type asr --build-version 11
+
+
+
+  Destroy a build using a build label
+
+  $ mix builds:destroy --build-label ASR_1922_11
+
+
+
+  Destroy a project and provide automatic confirmation
+
+  $ mix builds:destroy --build-label ASR_1922_11 --confirm ASR_1922_11
+```
+
+_See code: [src/commands/builds/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/builds/destroy.ts)_
+
+## `mix builds:export`
+
+export a project build
+
+```
+USAGE
+  $ mix builds:export [--build-label <value> | --build-type asr|dialog|nlu | -P <value> | --build-version <value>]
+    [-f <value>] [--overwrite]
+
+FLAGS
+  -P, --project=<value>    project ID
+  -f, --filepath=<value>   output file path (defaults to "build-<buildLabel>.zip")
+  --build-label=<value>    build label (format is <buildType>_<projectId>_<buildVersion>)
+  --build-type=<option>    build type
+                           <options: asr|dialog|nlu>
+  --build-version=<value>  build version
+  --overwrite              overwrite output file if it exists
+
+DESCRIPTION
+  export a project build
+
+  Use this command to export a project build. The build can be specified using
+  the build label or the combination of project ID, build type and build version.
+
+  The contents of the exported zip file depend on the role you have been granted
+  on the Mix platform.
+
+EXAMPLES
+  Export a build using a build label
+
+  $ mix builds:export --build-label ASR_29050_11
+
+
+
+  Export a build using project ID, build type and build version
+
+  $ mix builds:export -P 29050 --build-type asr --build-version 11 --overwrite
+```
+
+_See code: [src/commands/builds/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/builds/export.ts)_
+
+## `mix builds:get`
+
+get details about a build
+
+```
+USAGE
+  $ mix builds:get [--build-label <value> | --build-type asr|dialog|nlu | -P <value> | --build-version <value>]
+    [--columns <value> ] [--no-truncate |  | [--json | --csv | --yaml] | ]
+
+FLAGS
+  -P, --project=<value>    project ID
+  --build-label=<value>    build label (format is <buildType>_<projectId>_<buildVersion>)
+  --build-type=<option>    build type
+                           <options: asr|dialog|nlu>
+  --build-version=<value>  build version
+  --columns=<value>        only show provided columns (comma-separated) (with 'csv' flag only)
+  --csv                    output to csv format
+  --json                   output raw data in JSON format
+  --no-truncate            do not truncate output to fit screen
+  --yaml                   output raw data in YAML format
+
+DESCRIPTION
+  get details about a build
+
+  Use this command to get details about a particular build. The build can be
+  specified using the build label or the combination of project ID, build type
+  and build version.
+
+EXAMPLES
+  $ mix builds:get -P 1922 --build-type nlu --build-version 1
+```
+
+_See code: [src/commands/builds/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/builds/get.ts)_
+
+## `mix builds:latest`
+
+list latest build of each type
+
+```
+USAGE
+  $ mix builds:latest -P <value> [--columns <value> |  | --json | --yaml] [--csv |  | --no-truncate | ] [--filter
+    <value> |  | ] [--no-header |  | ]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated)
+  --csv                  output to csv format
+  --filter=<value>       filter property by partial string matching, ex: name=foo
+  --json                 output raw data in JSON format
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  list latest build of each type
+
+  Use this command to list the latest version for each build type of a particular
+  project.
+
+EXAMPLES
+  List latest builds
+
+  $ mix builds:latest -P 1922
+```
+
+_See code: [src/commands/builds/latest.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/builds/latest.ts)_
+
+## `mix builds:list`
+
+list builds
+
+```
+USAGE
+  $ mix builds:list --build-type asr|dialog|nlu -P <value> [--limit <value>] [--offset <value>] [--sort <value>]
+    [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |
+    |  | ]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --build-type=<option>  (required) build type
+                         <options: asr|dialog|nlu>
+  --columns=<value>      only show provided columns (comma-separated)
+  --csv                  output to csv format
+  --filter=<value>       filter property by partial string matching, ex: name=foo
+  --json                 output raw data in JSON format
+  --limit=<value>        limit maximum results returned (defaults to Mix API behavior)
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --offset=<value>       to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>         comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  list builds
+
+  Use this command to list all versions of a build type for a particular project.
+
+EXAMPLES
+  $ mix builds:list -P 1922 --build-type nlu
+```
+
+_See code: [src/commands/builds/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/builds/list.ts)_
+
+## `mix channels:activate`
+
+activate a channel
+
+```
+USAGE
+  $ mix channels:activate -P <value> -C <value> [--json |  | --yaml]
+
+FLAGS
+  -C, --channel=<value>  (required) channel ID
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  activate a channel
+
+  Use this command to activate a channel in a project.
+
+EXAMPLES
+  $ mix channels:activate -P 1922 \
+
+    --channel bc40667c-e0f6-11ec-9d64-0242ac120003
+```
+
+_See code: [src/commands/channels/activate.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/channels/activate.ts)_
+
+## `mix channels:configure`
+
+update channel details
+
+```
+USAGE
+  $ mix channels:configure -P <value> -C <value> -m <value> --color <value> [--json |  | --yaml]
+
+FLAGS
+  -C, --channel=<value>  (required) channel ID
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  -m, --mode=<value>...  (required) channel modes (audioscript|dtmf|interactivity|richtext|tts)
+  --color=<value>        (required) channel color
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  update channel details
+
+  Configure the modalities and color of an existing channel in a Mix project.
+
+  A note on channel modes and colors:
+  For your convenience, you may enter modes and colors case-insensitively.
+  In particular, you can spell any given mode/color with lowercase or capital letters,
+  and with dashes ('-') in place of underscores ('_'). The value will be internally converted
+  into the format the Mix API expects before the request is made. As an example, the values
+  'light-pink', 'light_Pink', and 'LIGHT-PINK' are all equivalent to Mix's 'LIGHT_PINK'.
+
+  Acceptable channel modes are:
+
+  audioscript
+  dtmf
+  interactivity
+  richtext
+  tts
+
+  Acceptable channel colors are:
+
+  blue          brown         corn-flower
+  cyan          green         grey
+  indigo        light-green   light-grey
+  light-orange  light-pink    light-purple
+  orange        pink          purple
+  ruby          salmon        sky
+  teal          yellow
+
+  IMPORTANT: Due to a current server-side limitation,
+  the command currently requires that both the
+  'mode' and 'color' flags are set.
+
+EXAMPLES
+  $ mix channels:configure -P 1922  \
+
+    --channel bc40667c-e0f6-11ec-9d64-0242ac120003 \
+
+    --mode DTMF --mode TTS \
+
+    --color SALMON
+```
+
+_See code: [src/commands/channels/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/channels/configure.ts)_
+
+## `mix channels:create`
+
+create a new channel
+
+```
+USAGE
+  $ mix channels:create --color <value> -m <value> --name <value> -P <value> [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  -m, --mode=<value>...  (required) channel modes (audioscript|dtmf|interactivity|richtext|tts)
+  --color=<value>        (required) channel color
+  --json                 output raw data in JSON format
+  --name=<value>         (required) channel name
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  create a new channel
+
+  Use this command to create a new channel in your Mix project.
+  A channel defines a collection of different modalities through
+  which users interact with your application. The currently available
+  modalities are:
+
+  audioscript
+  dtmf
+  interactivity
+  richtext
+  tts
+
+  Note that, for your convenience, this command will automatically convert
+  inputs to the 'mode' flag as close to the format of the above modes as possible,
+  by converting upper-case letters to lower-case and removing deliminating punctuation
+  ('-' and '_'). So, the modes 'audioscript', 'AUDIO-SCRIPT', and 'a_u-d_i-o----scriPT'
+  are all equivalent to the server-side value of 'AUDIO_SCRIPT'.
+
+  The same conversion is done for colours, except that dashes ('-') are replaced
+  with ('_') rather than being deleted. So, 'light-pink', 'light____pink', and
+  'LIGHT_PINK' are also equivalent.
+
+  Acceptable channel colors are:
+
+  blue          brown         corn-flower
+  cyan          green         grey
+  indigo        light-green   light-grey
+  light-orange  light-pink    light-purple
+  orange        pink          purple
+  ruby          salmon        sky
+  teal          yellow
+
+  IMPORTANT: Due to a current server-side limitation,
+  the command currently requires that both the
+  'mode' and 'color' flags are set.
+
+EXAMPLES
+  $ mix channels:create -P 1922 --name "New IVR channel" \
+      --mode tts --mode interactivity --color light-pink
+```
+
+_See code: [src/commands/channels/create.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/channels/create.ts)_
+
+## `mix channels:deactivate`
+
+deactivate a channel
+
+```
+USAGE
+  $ mix channels:deactivate -P <value> -C <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -C, --channel=<value>  (required) channel ID
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  deactivate a channel
+
+  Use this command to deactivate a channel in a project.
+
+EXAMPLES
+  $ mix channels:deactivate -P 1922 \
+
+    --channel bc40667c-e0f6-11ec-9d64-0242ac120003 \
+
+    --confirm bc40667c-e0f6-11ec-9d64-0242ac120003
+```
+
+_See code: [src/commands/channels/deactivate.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/channels/deactivate.ts)_
+
+## `mix channels:rename`
+
+rename a channel
+
+```
+USAGE
+  $ mix channels:rename -P <value> -C <value> --new-name <value> [--json |  | --yaml]
+
+FLAGS
+  -C, --channel=<value>  (required) channel ID
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --new-name=<value>     (required) new channel name
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  rename a channel
+
+  Use this command to change the name of a channel in a project.
+
+EXAMPLES
+  $ mix channels:rename -P 1922 \
+
+    --channel bc40667c-e0f6-11ec-9d64-0242ac120003 \
+
+    --new-name "voice channel"
+```
+
+_See code: [src/commands/channels/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/channels/rename.ts)_
+
+## `mix data-hosts:latest`
+
+list latest data host details
+
+```
+USAGE
+  $ mix data-hosts:latest -M <value> -P <value> [-D <value>] [--columns <value> |  | [--json | --csv | --yaml] | ]
+    [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+
+FLAGS
+  -D, --deployment-flow=<value>  deployment flow ID
+  -M, --mix-app=<value>          (required) Mix application ID
+  -P, --project=<value>          (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>              only show provided columns (comma-separated)
+  --csv                          output to csv format
+  --filter=<value>               filter property by partial string matching, ex: name=foo
+  --json                         output raw data in JSON format
+  --no-header                    hide table header from output
+  --no-truncate                  do not truncate output to fit screen
+  --sort=<value>                 property to sort by (prepend '-' for descending)
+  --yaml                         output raw data in YAML format
+
+DESCRIPTION
+  list latest data host details
+
+  Use this command to retrieve the list of the data hosts
+  associated with the last generated dialog build.
+
+EXAMPLES
+  $ mix data-hosts:latest -D 658 -M 34 -P 619090
+```
+
+_See code: [src/commands/data-hosts/latest.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/data-hosts/latest.ts)_
+
+## `mix data-hosts:list`
+
+list data host details
+
+```
+USAGE
+  $ mix data-hosts:list -M <value> [--build-label <value> | -P <value> | --build-version <value>] [-D <value>]
+    [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |
+    |  | ] [--sort <value>]
+
+FLAGS
+  -D, --deployment-flow=<value>  deployment flow ID
+  -M, --mix-app=<value>          (required) Mix application ID
+  -P, --project=<value>          project ID
+  --build-label=<value>          build label (format is <buildType>_<projectId>_<buildVersion>)
+  --build-version=<value>        build version
+  --columns=<value>              only show provided columns (comma-separated)
+  --csv                          output to csv format
+  --filter=<value>               filter property by partial string matching, ex: name=foo
+  --json                         output raw data in JSON format
+  --no-header                    hide table header from output
+  --no-truncate                  do not truncate output to fit screen
+  --sort=<value>                 property to sort by (prepend '-' for descending)
+  --yaml                         output raw data in YAML format
+
+DESCRIPTION
+  list data host details
+
+  Use this command to list data host details for a particular Mix Application ID
+  and dialog build. The build can be specified using the build label or the
+  combination of project ID and build version. The Mix Application ID can be
+  retrieved using the applications:list command.
+
+EXAMPLES
+  $ mix data-hosts:list -D 66 -M 62 -P 14990 --build-version 1
+```
+
+_See code: [src/commands/data-hosts/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/data-hosts/list.ts)_
+
+## `mix data-types:list`
+
+list data types
+
+```
+USAGE
+  $ mix data-types:list [--json |  | --yaml]
+
+FLAGS
+  --json  output raw data in JSON format
+  --yaml  output raw data in YAML format
+
+DESCRIPTION
+  list data types
+
+  Use this command to list the available data types.
+
+EXAMPLES
+  $ mix data-types:list
+```
+
+_See code: [src/commands/data-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/data-types/list.ts)_
+
+## `mix deployment-flows:list`
+
+list deployment flows
+
+```
+USAGE
+  $ mix deployment-flows:list -O <value> [--limit <value>] [--offset <value>] [--sort <value>] [--columns <value> |  |
+    [--json | --csv | --yaml] | ] [--no-truncate |  |  | ]
+
+FLAGS
+  -O, --organization=<value>  (required) organization ID (defaults to MIX_ORGANIZATION)
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --json                      output raw data in JSON format
+  --limit=<value>             limit maximum results returned (defaults to Mix API behavior)
+  --no-truncate               do not truncate output to fit screen
+  --offset=<value>            to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>              comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list deployment flows
+
+  Use this command to list all deployment flows for a specific organization.
+  The organization ID can be retrieved by using the organizations:list command.
+
+EXAMPLES
+  $ mix deployment-flows:list -O 64
+```
+
+_See code: [src/commands/deployment-flows/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/deployment-flows/list.ts)_
+
+## `mix engine-packs:list`
+
+list engine packs
+
+```
+USAGE
+  $ mix engine-packs:list -O <value> [--json |  | --yaml]
+
+FLAGS
+  -O, --organization=<value>  (required) organization ID (defaults to MIX_ORGANIZATION)
+  --json                      output raw data in JSON format
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list engine packs
+
+  Use this command to list the engine packs available to a specific organization.
+
+EXAMPLES
+  $ mix engine-packs:list -O 64
+```
+
+_See code: [src/commands/engine-packs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/engine-packs/list.ts)_
+
+## `mix entities:configure`
+
+configure an entity
+
+```
+USAGE
+  $ mix entities:configure -E <value> --entity-type base|freeform|list|regex|relational|rule-based -P <value>
+    [--anaphora-type not-set|ref-moment|ref-person|ref-place|ref-thing] [--data-type
+    alphanum|amount|boolean|date|digits|distance|no-format|not-set|number|temperature|time|yes-no] [--dynamic] [--has-a
+    <value>] [--is-a <value>] [-L <value>] [--no-canonicalize] [--pattern <value>] [--sensitive] [--json |  | --yaml]
+
+FLAGS
+  -E, --entity=<value>      (required) entity name
+  -L, --locale=<value>      locale for regex entity
+  -P, --project=<value>     (required) project ID (defaults to MIX_PROJECT)
+  --anaphora-type=<option>  anaphora type
+                            <options: not-set|ref-moment|ref-person|ref-place|ref-thing>
+  --data-type=<option>      data type of entity
+                            <options: alphanum|amount|boolean|date|digits|distance|no-format|not-set|number|temperature|
+                            time|yes-no>
+  --dynamic                 make list entity dynamic
+  --entity-type=<option>    (required) entity type
+                            <options: base|freeform|list|regex|relational|rule-based>
+  --has-a=<value>...        define hasA relationship for relational entity
+  --is-a=<value>            define isA relationship for relational entity
+  --json                    output raw data in JSON format
+  --no-canonicalize         prevent canonicalization
+  --pattern=<value>         regular expression for regex entity
+  --sensitive               mask user sentitive data in logs
+  --yaml                    output raw data in YAML format
+
+DESCRIPTION
+  configure an entity
+
+  Use this command to configure an entity in a project.
+
+  NOTE: This command cannot change the type of an entity.
+  When using this command, you must provide the current type
+  of the entity. Use command entities:convert to change the
+  type of an entity.
+
+  Mix supports several types of entities: freeform, list, regex,
+  relational and rule-based. There are many attributes that can
+  be configured for an entity and a good number of these attributes
+  are common to all entity types. However, certain attributes apply
+  to specific entity types only.
+
+  Regex entities make use of regular expressions specific to a single
+  locale. The 'pattern' and 'locale' flags matter only to entities
+  of type "regex". It is recommended to surround the pattern
+  value with quotes, especially if the escape character "\" is used
+  in the pattern. See examples below.
+
+  Relationial entities can have zero or one isA relation and
+  zero or many hasA relations. One 'is-a' or 'has-a' flag must be
+  set at a minimum for an entity of type "relational".
+
+  The examples below show how to configure each type of entity.
+  In each example, every allowed flag is used.
+  Note that when a value is not provided for a particular flag,
+  the corresponding property in the entity is not modified.
+
+
+EXAMPLES
+  Configure a freeform entity
+
+  $ mix entities:configure -P 1922 -E MESSAGE --entity-type freeform \
+
+    --sensitive --no-canonicalize --data-type not-set
+
+
+
+  Configure a list entity
+
+  $ mix entities:configure -P 1922 -E DRINK_SIZE --entity-type list \
+
+    --dynamic --sensitive --no-canonicalize --anaphora-type not-set \
+
+    --data-type not-set
+
+
+
+  Configure a regex entity
+
+  $ mix entities:configure -P 1922 -E PHONE_NUMBER --entity-type regex \
+
+    --locale en-US --pattern "\d{10}" --sensitive --no-canonicalize \
+
+    --anaphora-type not-set --data-type digits
+
+
+
+  Configure a relational entity
+
+  $ mix entities:configure -P 1922 --E FROM_CITY --entity-type relational \
+
+    --is-a CITY --sensitive --no-canonicalize --anaphora-type not-set \
+
+    --data-type not-set
+
+
+
+  Configure a rule-based entity
+
+  $ mix entities:configure -P 1922 -E CARD_TYPE --entity-type rule-based \
+
+    --sensitive --no-canonicalize --anaphora-type not-set --data-type not-set
+```
+
+_See code: [src/commands/entities/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/configure.ts)_
+
+## `mix entities:convert`
+
+convert an entity to a different type
+
+```
+USAGE
+  $ mix entities:convert -E <value> -P <value> --to-entity-type base|freeform|list|regex|relational|rule-based
+    [--has-a <value>] [--is-a <value>] [--pattern <value>] [--json |  | --yaml]
+
+FLAGS
+  -E, --entity=<value>       (required) entity name
+  -P, --project=<value>      (required) project ID (defaults to MIX_PROJECT)
+  --has-a=<value>...         define hasA relationship for relational entity
+  --is-a=<value>             define isA relationship for relational entity
+  --json                     output raw data in JSON format
+  --pattern=<value>          regular expression for regex entity
+  --to-entity-type=<option>  (required) new entity type
+                             <options: base|freeform|list|regex|relational|rule-based>
+  --yaml                     output raw data in YAML format
+
+DESCRIPTION
+  convert an entity to a different type
+
+  Use this command to convert an entity to a different type.
+
+  Mix supports several types of entities: freeform, list, regex,
+  relational and rule-based. If converting to a regex or rule-based
+  entity type, you will have to provide additional information as
+  explained below.
+
+  Regex entities make use of regular expressions specific to a single
+  locale. Use the 'pattern' flag to provide the regular expression for
+  the converted entity. It is recommended to surround the pattern value
+  with quotes, especially if the escape character "\" is used in the
+  pattern (see examples below). The regular expression provided gets
+  applied to the entity across all locales in the project. If the regular
+  expression for the entity is locale-dependent, then use the entities:configure
+  command to update the regular expression for the relevant locales.
+
+  Relational entities can have zero or one isA relation and
+  zero or many hasA relations. One 'is-a' or 'has-a' flag must be
+  set at a minimum whent converting an entity to the "relational" type.
+
+  The examples below show how to convert an entity to each possible
+  type of entity.
+
+
+EXAMPLES
+  Convert an entity to a freeform entity
+
+  $ mix entities:convert -P 1922 -E MY_ENTITY --to-entity-type freeform
+
+
+
+  Convert an entity to a list entity
+
+  $ mix entities:convert -P 1922 -E MY_ENTITY --to-entity-type list
+
+
+
+  Convert an entity to a regex entity
+
+  $ mix entities:convert -P 1922 -E MY_ENTITY --to-entity-type regex \
+
+    --pattern "\d{10}"
+
+
+
+  Convert an entity to a relational entity
+
+  $ mix entities:convert -P 1922 --E MY_ENTITY --to-entity-type relational
+
+    --is-a CITY
+
+
+
+  Convert an entity to a rule-based entity
+
+  $ mix entities:convert -P 1922 -E MY_ENTITY --to-entity-type rule-based
+```
+
+_See code: [src/commands/entities/convert.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/convert.ts)_
+
+## `mix entities:create`
+
+create a new entity
+
+```
+USAGE
+  $ mix entities:create --entity-type base|freeform|list|regex|relational|rule-based --name <value> -P <value>
+    [--anaphora-type not-set|ref-moment|ref-person|ref-place|ref-thing] [--data-type
+    alphanum|amount|boolean|date|digits|distance|no-format|not-set|number|temperature|time|yes-no] [--dynamic] [--has-a
+    <value>] [--is-a <value>] [-L <value>] [--no-canonicalize] [--pattern <value>] [--sensitive] [--json |  | --yaml]
+
+FLAGS
+  -L, --locale=<value>      locale for regex entity
+  -P, --project=<value>     (required) project ID (defaults to MIX_PROJECT)
+  --anaphora-type=<option>  [default: not-set] anaphora type
+                            <options: not-set|ref-moment|ref-person|ref-place|ref-thing>
+  --data-type=<option>      [default: not-set] data type of entity
+                            <options: alphanum|amount|boolean|date|digits|distance|no-format|not-set|number|temperature|
+                            time|yes-no>
+  --dynamic                 make list entity dynamic
+  --entity-type=<option>    (required) entity type
+                            <options: base|freeform|list|regex|relational|rule-based>
+  --has-a=<value>...        define hasA relationship for relational entity
+  --is-a=<value>            define isA relationship for relational entity
+  --json                    output raw data in JSON format
+  --name=<value>            (required) new entity name
+  --no-canonicalize         prevent canonicalization
+  --pattern=<value>         regular expression for regex entity
+  --sensitive               mask user sentitive data in logs
+  --yaml                    output raw data in YAML format
+
+DESCRIPTION
+  create a new entity
+
+  Use this command to create a new entity in a project.
+
+  Mix supports several types of entities: freeform, list, regex,
+  relational and rule-based. There are many attributes that can
+  be passed for the creation of an entity and a good number of
+  these attributes are common to all entity types. However, certain
+  attributes are mandatory and apply to specific entity types only.
+
+  Regex entities make use of regular expressions specific to a single
+  locale. The 'pattern' and 'locale' flags must be set when creating
+  an entity of type "regex". It is recommended to surround the pattern
+  value with quotes, especially if the escape character "\" is used
+  in the pattern. See examples below.
+
+  Relationial entities can have zero or one isA relation and
+  zero or many hasA relations. One 'is-a' or 'has-a' flag must be
+  set at a minimum when creating an entity of type "relational".
+
+  The 'entity-type', 'name' and 'project' flags are mandatory for
+  the creation of any entity type.
+
+  The examples below show how to create each type of entity.
+  In each example, every allowed or mandatory flag is used.
+  Note that many flags have default values and do not need to be
+  explicitly provided.
+
+
+EXAMPLES
+  Create a freeform entity
+
+  $ mix entities:create -P 1922 --entity-type=freeform --name MESSAGE \
+
+    --sensitive --no-canonicalize --data-type not-set
+
+
+
+  Create a list entity
+
+  $ mix entities:create -P 1922 --entity-type=list --name DRINK_SIZE \
+
+    --dynamic --sensitive --no-canonicalize --anaphora-type not-set \
+
+    --data-type not-set
+
+
+
+  Create a regex entity
+
+  $ mix entities:create -P 1922 --entity-type=regex --name PHONE_NUMBER \
+
+    --locale en-US --pattern "\d{10}" --sensitive --no-canonicalize \
+
+    --anaphora-type not-set --data-type digits
+
+
+
+  Create a relational entity
+
+  $ mix entities:create -P 1922 --entity-type=relational --name ARRIVAL_CITY \
+
+    --is-a CITY --sensitive --no-canonicalize --anaphora-type not-set \
+
+    --data-type not-set
+
+
+
+  Create a rule-based entity
+
+  $ mix entities:create -P 1922 --entity-type=rule-based --name CARD_TYPE \
+
+    --sensitive --no-canonicalize --anaphora-type not-set --data-type not-set
+```
+
+_See code: [src/commands/entities/create.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/create.ts)_
+
+## `mix entities:destroy`
+
+destroy an entity
+
+```
+USAGE
+  $ mix entities:destroy -E <value> -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -E, --entity=<value>   (required) entity name
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  destroy an entity
+
+  Use this command to permanently delete an entity from a project.
+
+EXAMPLES
+  $ mix entities:destroy -P 1922 -E CoffeeSize
+```
+
+_See code: [src/commands/entities/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/destroy.ts)_
+
+## `mix entities:get`
+
+get details about an entity
+
+```
+USAGE
+  $ mix entities:get -E <value> -P <value> [--columns <value> --csv] [--no-truncate |  | --json | --yaml]
+
+FLAGS
+  -E, --entity=<value>   (required) entity name
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated) (with 'csv' flag only)
+  --csv                  output to csv format
+  --json                 output raw data in JSON format
+  --no-truncate          do not truncate output to fit screen
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  get details about an entity
+
+  Use this command to get details about a particular entity in a project.
+
+  The set of properties listed in the human-readable output of this command
+  varies with the type of the entity queried. However, the CSV output provides a
+  column for each of the properties present in the superset of all entity type
+  properties. This way, a consistent set of columns is always presented.
+
+  Use the 'json' or 'yaml' flag to see the original data returned by the
+  server.
+
+
+EXAMPLES
+  $ mix entities:get -P 1922 -E DrinkSize
+```
+
+_See code: [src/commands/entities/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/get.ts)_
+
+## `mix entities:list`
+
+list entities
+
+```
+USAGE
+  $ mix entities:list -P <value> [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ]
+    [--no-header |  | ] [--no-truncate |  |  | ] [--with-entity-type base|freeform|list|regex|relational|rule-based]
+
+FLAGS
+  -P, --project=<value>        (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>            only show provided columns (comma-separated)
+  --csv                        output to csv format
+  --filter=<value>             filter property by partial string matching, ex: name=foo
+  --json                       output raw data in JSON format
+  --no-header                  hide table header from output
+  --no-truncate                do not truncate output to fit screen
+  --with-entity-type=<option>  entity type
+                               <options: base|freeform|list|regex|relational|rule-based>
+  --yaml                       output raw data in YAML format
+
+DESCRIPTION
+  list entities
+
+  Use this command to list all entities available in a specific project.
+
+EXAMPLES
+  List all entities
+
+  $ mix entities:list -P 1922
+
+
+
+  List all list-type entities
+
+  $ mix entities:list -P 1922 --with-entity-type list
+```
+
+_See code: [src/commands/entities/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/list.ts)_
+
+## `mix entities:rename`
+
+rename an entity
+
+```
+USAGE
+  $ mix entities:rename -E <value> --new-name <value> -P <value> [--json |  | --yaml]
+
+FLAGS
+  -E, --entity=<value>   (required) entity name
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --new-name=<value>     (required) new entity name
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  rename an entity
+
+  Use this command to rename an entity in a project.
+
+EXAMPLES
+  $ mix entities:rename -P 1922 -E DrinkSize --new-name DrinkFormat
+```
+
+_See code: [src/commands/entities/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entities/rename.ts)_
+
+## `mix entity-types:list`
+
+list entity types
+
+```
+USAGE
+  $ mix entity-types:list [--json |  | --yaml]
+
+FLAGS
+  --json  output raw data in JSON format
+  --yaml  output raw data in YAML format
+
+DESCRIPTION
+  list entity types
+
+  Use this command to list the available entity types.
+
+EXAMPLES
+  $ mix entity-types:list
+```
+
+_See code: [src/commands/entity-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entity-types/list.ts)_
+
+## `mix env-configs:list`
+
+list environment configurations
+
+```
+USAGE
+  $ mix env-configs:list -P <value> [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ]
+    [--no-header |  | ] [--no-truncate |  |  | ]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated)
+  --csv                  output to csv format
+  --filter=<value>       filter property by partial string matching, ex: name=foo
+  --json                 output raw data in JSON format
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  list environment configurations
+
+  Use this command to list all environment configurations for a specific project.
+
+EXAMPLES
+  List environment configurations for project ID 29050
+
+  $ mix projects:list -P 29050
+```
+
+_See code: [src/commands/env-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/env-configs/list.ts)_
+
+## `mix environments:list`
+
+list available environments
+
+```
+USAGE
+  $ mix environments:list -O <value> [--limit <value>] [--offset <value>] [--sort <value>] [--columns <value> |  |
+    [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ]
+
+FLAGS
+  -O, --organization=<value>  (required) organization ID (defaults to MIX_ORGANIZATION)
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --json                      output raw data in JSON format
+  --limit=<value>             limit maximum results returned (defaults to Mix API behavior)
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --offset=<value>            to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>              comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list available environments
+
+  Use this command to list all environments available to a specific organization.
+
+EXAMPLES
+  $ mix environments:list -O 64
+```
+
+_See code: [src/commands/environments/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/environments/list.ts)_
+
+## `mix geographies:list`
+
+list geographies
+
+```
+USAGE
+  $ mix geographies:list [--limit <value>] [--offset <value>] [--sort <value>] [--columns <value> |  | [--json | --csv
+    | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ]
+
+FLAGS
+  --columns=<value>  only show provided columns (comma-separated)
+  --csv              output to csv format
+  --filter=<value>   filter property by partial string matching, ex: name=foo
+  --json             output raw data in JSON format
+  --limit=<value>    limit maximum results returned (defaults to Mix API behavior)
+  --no-header        hide table header from output
+  --no-truncate      do not truncate output to fit screen
+  --offset=<value>   to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>     comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --yaml             output raw data in YAML format
+
+DESCRIPTION
+  list geographies
+
+  Use this command to list the geographies available on the platform.
+
+EXAMPLES
+  $ mix geographies:list
+```
+
+_See code: [src/commands/geographies/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/geographies/list.ts)_
+
+## `mix grammars:export`
+
+export the grammars for an entity
+
+```
+USAGE
+  $ mix grammars:export -E <value> -P <value> [-f <value>] [--overwrite]
+
+FLAGS
+  -E, --entity=<value>    (required) entity name
+  -P, --project=<value>   (required) project ID (defaults to MIX_PROJECT)
+  -f, --filepath=<value>  output file path (defaults to "grammars-<projectId>-<entity>.zip")
+  --overwrite             overwrite output file if it exists
+
+DESCRIPTION
+  export the grammars for an entity
+
+  Use this command to export the rule-based GrXML grammars for an entity.
+  Note that rule-based grammars are restricted to Nuance Professional Services users
+  and not available to all users.
+
+EXAMPLES
+  Export the grammars for an entity to a zip file
+
+  $ mix grammars:export -P 29050 -E DrinkSize --overwrite
+```
+
+_See code: [src/commands/grammars/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/grammars/export.ts)_
+
+## `mix grammars:replace`
+
+replace the GrXML grammars for an entity 
+
+```
+USAGE
+  $ mix grammars:replace -E <value> -f <value> -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -E, --entity=<value>    (required) entity name
+  -P, --project=<value>   (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>   skip confirmation prompt by pre-supplying value
+  -f, --filepath=<value>  (required) input file path
+  --json                  output raw data in JSON format
+  --yaml                  output raw data in YAML format
+
+DESCRIPTION
+  replace the GrXML grammars for an entity
+
+  Use this command to replace the rule-based GrXML grammars for an entity.
+  The GrXML files must be provided in a .zip file, in a folder identifying
+  the locale for the grammar (for example, en-US/grammar.grxml).
+  Note that rule-based grammars are restricted to Nuance Professional Services
+  users and not available to all users.
+
+EXAMPLES
+  Replace the GrXML grammars for an entity
+
+  $ mix grammars:replace -P 29050 -E DrinkSize -f 29050_DrinkSize.zip
+
+
+
+  Replace the GrXML grammars for an entity using pre-confirmation
+
+  $ mix grammars:replace -P 29050 -E DrinkSize -f 29050_DrinkSize.zip -c DrinkSize
+```
+
+_See code: [src/commands/grammars/replace.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/grammars/replace.ts)_
+
 ## `mix help [COMMAND]`
 
 Display help for mix.
@@ -225,6 +2111,1163 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.22/src/commands/help.ts)_
+
+## `mix init`
+
+initialize mix-cli configuration
+
+```
+USAGE
+  $ mix init
+
+DESCRIPTION
+  initialize mix-cli configuration
+
+  Use this command to initialize the mix-cli configuration. Elements of the
+  configuration can also be overridden using environment variables.
+
+EXAMPLES
+  $ mix init
+```
+
+_See code: [src/commands/init.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/init.ts)_
+
+## `mix intents:create`
+
+create a new intent
+
+```
+USAGE
+  $ mix intents:create --name <value> -P <value> [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --name=<value>         (required) new intent name
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  create a new intent
+
+  Use this command to create a new intent in a project.
+
+EXAMPLES
+  $ mix intents:create -P 1922 --name ORDER_DRINK
+```
+
+_See code: [src/commands/intents/create.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/intents/create.ts)_
+
+## `mix intents:destroy`
+
+destroy an intent
+
+```
+USAGE
+  $ mix intents:destroy -I <value> -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -I, --intent=<value>   (required) intent name
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  destroy an intent
+
+  Use this command to permanently delete an intent from a project.
+
+EXAMPLES
+  $ mix intents:destroy -P 1922 -I ORDER_DRINK
+```
+
+_See code: [src/commands/intents/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/intents/destroy.ts)_
+
+## `mix intents:get`
+
+get details about an intent
+
+```
+USAGE
+  $ mix intents:get -I <value> -P <value> [--columns <value> ] [--no-truncate |  | [--json | --csv | --yaml] | ]
+
+FLAGS
+  -I, --intent=<value>   (required) intent name
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated) (with 'csv' flag only)
+  --csv                  output to csv format
+  --json                 output raw data in JSON format
+  --no-truncate          do not truncate output to fit screen
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  get details about an intent
+
+  Use this command to get details about a particular intent in a project.
+
+EXAMPLES
+  $ mix intents:get -P 1922 -I ORDER_DRINK
+```
+
+_See code: [src/commands/intents/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/intents/get.ts)_
+
+## `mix intents:list`
+
+list intents
+
+```
+USAGE
+  $ mix intents:list -P <value> [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ]
+    [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated)
+  --csv                  output to csv format
+  --filter=<value>       filter property by partial string matching, ex: name=foo
+  --json                 output raw data in JSON format
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --sort=<value>         property to sort by (prepend '-' for descending)
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  list intents
+
+  Use this command to list all intents available in a specific project.
+
+EXAMPLES
+  $ mix intents:list -P 1922
+```
+
+_See code: [src/commands/intents/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/intents/list.ts)_
+
+## `mix intents:rename`
+
+rename an intent
+
+```
+USAGE
+  $ mix intents:rename -I <value> --new-name <value> -P <value> [--json |  | --yaml]
+
+FLAGS
+  -I, --intent=<value>   (required) intent name
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --new-name=<value>     (required) new intent name
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  rename an intent
+
+  Use this command to rename an intent in a project.
+
+EXAMPLES
+  $ mix intents:rename -P 1922 -I ORDER_DRINK --new-name ORDER_COFFEE
+```
+
+_See code: [src/commands/intents/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/intents/rename.ts)_
+
+## `mix jobs:cancel`
+
+cancel a job
+
+```
+USAGE
+  $ mix jobs:cancel -J <value> -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -J, --job=<value>      (required) job ID
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  cancel a job
+
+  Use this command to cancel a job. Canceling a job does not necessarily
+  terminate it but allows a similar job to be launched before the completion
+  of the original one.
+
+EXAMPLES
+  $ mix jobs:cancel -P 1922 -J 15d4d4ce-7cc3-45f6-ab38-aad326e6fc20
+```
+
+_See code: [src/commands/jobs/cancel.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/jobs/cancel.ts)_
+
+## `mix jobs:get`
+
+get details about a job
+
+```
+USAGE
+  $ mix jobs:get -J <value> -P <value> [--columns <value> ] [--no-header | [--json | --csv | --yaml] | ]
+    [--no-truncate |  |  | ] [--watch]
+
+FLAGS
+  -J, --job=<value>      (required) job ID
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated) (with 'csv' flag only)
+  --csv                  output to csv format
+  --json                 output raw data in JSON format
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --watch                poll status of job every minute
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  get details about a job
+
+  Use this command to get details about a particular job.
+
+EXAMPLES
+  $ mix jobs:get -P 1922 -J 25a08872-c635-43f1-b459-5bd98a1c2576
+```
+
+_See code: [src/commands/jobs/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/jobs/get.ts)_
+
+## `mix jobs:list`
+
+list jobs for a project
+
+```
+USAGE
+  $ mix jobs:list -P <value> [--limit <value>] [--offset <value>] [--sort <value>] [--columns <value> |  |
+    [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated)
+  --csv                  output to csv format
+  --filter=<value>       filter property by partial string matching, ex: name=foo
+  --json                 output raw data in JSON format
+  --limit=<value>        limit maximum results returned (defaults to Mix API behavior)
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --offset=<value>       to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>         comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  list jobs for a project
+
+  Use this command to list all jobs related to a particular project.
+
+EXAMPLES
+  $ mix jobs:list -P 1922
+```
+
+_See code: [src/commands/jobs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/jobs/list.ts)_
+
+## `mix language-topics:list`
+
+list language topics for an organization
+
+```
+USAGE
+  $ mix language-topics:list -O <value> [--columns <value> |  | [--json |  | --yaml] | ] [--filter <value> |  | ]
+    [--no-header |  | ] [--no-truncate |  |  | ] [--sort <value>]
+
+FLAGS
+  -O, --organization=<value>  (required) organization ID (defaults to MIX_ORGANIZATION)
+  --columns=<value>           only show provided columns (comma-separated)
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --json                      output raw data in JSON format
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --sort=<value>              property to sort by (prepend '-' for descending)
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list language topics for an organization
+
+  Use this command to list language topics available to a specific organization.
+
+EXAMPLES
+  $ mix language-topics:list -O 64
+```
+
+_See code: [src/commands/language-topics/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/language-topics/list.ts)_
+
+## `mix literals:export`
+
+export entity literals
+
+```
+USAGE
+  $ mix literals:export -E <value> -L <value> -P <value> [-f <value>] [--overwrite]
+
+FLAGS
+  -E, --entity-name=<value>  (required) entity name
+  -L, --locale=<value>...    (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -P, --project=<value>      (required) project ID (defaults to MIX_PROJECT)
+  -f, --filepath=<value>     output file path (defaults to "literals-<projectId>-<entity>-<locale>.zip")
+  --overwrite                overwrite output file if it exists
+
+DESCRIPTION
+  export entity literals
+
+  Use this command to export literal-value pairs for a specific entity.
+  It is possible to specify the locale(s) for which the pairs should be exported.
+
+  The contents of the exported zip file depend on the role you have been granted
+  on the Mix platform.
+
+EXAMPLES
+  $ mix literals:export -P 29050 -E DrinkSize -L en-US --overwrite
+```
+
+_See code: [src/commands/literals/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/literals/export.ts)_
+
+## `mix literals:import`
+
+import entity literals, appending to existing literals by default
+
+```
+USAGE
+  $ mix literals:import -E <value> -f <value> -L <value> -P <value> [-c <value>] [--json |  | --yaml] [--replace]
+
+FLAGS
+  -E, --entity-name=<value>  (required) entity name
+  -L, --locale=<value>       (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -P, --project=<value>      (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>      skip confirmation prompt by pre-supplying value
+  -f, --filepath=<value>     (required) input file path
+  --json                     output raw data in JSON format
+  --replace                  replace, rather than append, existing entity literals
+  --yaml                     output raw data in YAML format
+
+DESCRIPTION
+  import entity literals, appending to existing literals by default
+
+  Use this command to import literal-value pairs into a project. By default, the
+  literal-value pairs are appended to the project in the specified locale. It is
+  also possible to completely replace literal-value pairs for the specified locale
+  by using the 'replace' flag.
+
+  The import needs to be confirmed by re-typing the entity name when prompted.
+  It can also be pre-confirmed by using the 'confirm' flag.
+
+EXAMPLES
+  Import entity literals by appending
+
+  $ mix literals:import -P 29050 -E DrinkSize -L en-US -f literals.trsx
+
+
+
+  Import entity literals by appending using pre-confirmation
+
+  $ mix literals:import -P 29050 -E DrinkSize -L en-US -f literals.trsx -c DrinkSize
+
+
+
+  Import entity literals by replacing
+
+  $ mix literals:import -P 29050 -E DrinkSize -L en-US -f literals.trsx --replace
+
+
+
+  Import entity literals by replacing using pre-confirmation
+
+  $ mix literals:import -P 29050 -E DrinkSize -L en-US -f literals.trsx -c DrinkSize --replace
+```
+
+_See code: [src/commands/literals/import.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/literals/import.ts)_
+
+## `mix locks:get`
+
+get details about a project lock
+
+```
+USAGE
+  $ mix locks:get -P <value> [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  get details about a project lock
+
+  Use this command to get details about a project lock.
+  A project cannot be edited while it is locked.
+
+EXAMPLES
+  Get details about a project lock
+
+  $ mix locks:get -P 1922"
+```
+
+_See code: [src/commands/locks/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/locks/get.ts)_
+
+## `mix locks:list`
+
+list project locks
+
+```
+USAGE
+  $ mix locks:list [-P <value>] [-U <value>] [-O <value>] [--limit <value>] [--offset <value>] [--sort <value>]
+    [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |
+    |  | ]
+
+FLAGS
+  -O, --organization=<value>  organization ID (defaults to MIX_ORGANIZATION)
+  -P, --project=<value>       project ID (defaults to MIX_PROJECT)
+  -U, --user=<value>          user ID
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --json                      output raw data in JSON format
+  --limit=<value>             limit maximum results returned (defaults to Mix API behavior)
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --offset=<value>            to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>              comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list project locks
+
+  Use this command to get a list of all project locks.
+  The list can be constrained using the project, organization
+  and/or user flags.
+
+  A project cannot be edited while it is locked.
+
+EXAMPLES
+  list project locks
+
+  $ mix locks:list -P 249 -U 32
+```
+
+_See code: [src/commands/locks/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/locks/list.ts)_
+
+## `mix ontology:export`
+
+export ontology
+
+```
+USAGE
+  $ mix ontology:export -L <value> -P <value> [-f <value>] [--overwrite]
+
+FLAGS
+  -L, --locale=<value>...  (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -P, --project=<value>    (required) project ID (defaults to MIX_PROJECT)
+  -f, --filepath=<value>   output file path (defaults to "ontology-<projectId>-<locale>.zip")
+  --overwrite              overwrite output file if it exists
+
+DESCRIPTION
+  export ontology
+
+  Use this command to export the ontology for a particular project.
+
+  The contents of the exported zip file depend on the role you have been granted
+  on the Mix platform.
+
+EXAMPLES
+  $ mix ontology:export -P 29050 -L en-US --overwrite
+```
+
+_See code: [src/commands/ontology/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/ontology/export.ts)_
+
+## `mix ontology:import`
+
+import by appending to existing ontology
+
+```
+USAGE
+  $ mix ontology:import -f <value> -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>   (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>   skip confirmation prompt by pre-supplying value
+  -f, --filepath=<value>  (required) input file path
+  --json                  output raw data in JSON format
+  --yaml                  output raw data in YAML format
+
+DESCRIPTION
+  import by appending to existing ontology
+
+  Use this command to import an ontology into a specific project. The provided
+  ontology can only be appended to the existing ontology.
+
+  The import needs to be confirmed by re-typing the project ID when prompted.
+  It can also be pre-confirmed by using the 'confirm' flag.
+
+EXAMPLES
+  Import an ontology
+
+  $ mix ontology:import -P 29050 -f ontology.zip
+
+
+
+  Import an ontology using pre-confirmation
+
+  $ mix ontology:import -P 29050 -f ontology.zip -c 29050
+```
+
+_See code: [src/commands/ontology/import.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/ontology/import.ts)_
+
+## `mix organizations:list`
+
+list available Mix organizations
+
+```
+USAGE
+  $ mix organizations:list [--all] [--full] [--limit <value>] [--offset <value>] [--sort <value>] [--columns <value> | 
+    | [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ] [--no-truncate |  |  | ]
+    [--with-organization-type personal|standard]
+
+FLAGS
+  --all                              show all organizations
+  --columns=<value>                  only show provided columns (comma-separated)
+  --csv                              output to csv format
+  --filter=<value>                   filter property by partial string matching, ex: name=foo
+  --full                             display all organization details, including members count
+  --json                             output raw data in JSON format
+  --limit=<value>                    limit maximum results returned (defaults to Mix API behavior)
+  --no-header                        hide table header from output
+  --no-truncate                      do not truncate output to fit screen
+  --offset=<value>                   to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>                     property to sort by (prepend '-' for descending)
+  --with-organization-type=<option>  organization type
+                                     <options: personal|standard>
+  --yaml                             output raw data in YAML format
+
+DESCRIPTION
+  list available Mix organizations
+
+  Use this command to list the organizations you are part of.
+
+EXAMPLES
+  $ mix organizations:list
+```
+
+_See code: [src/commands/organizations/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/organizations/list.ts)_
+
+## `mix projects:build`
+
+build a project
+
+```
+USAGE
+  $ mix projects:build -L <value> -P <value> [--build-type asr|dialog|nlu] [--notes <value>] [--nlu-model-type
+    accurate|fast] [--json |  | --yaml]
+
+FLAGS
+  -L, --locale=<value>...    (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -P, --project=<value>      (required) project ID (defaults to MIX_PROJECT)
+  --build-type=<option>...   [default: nlu] build type
+                             <options: asr|dialog|nlu>
+  --json                     output raw data in JSON format
+  --nlu-model-type=<option>  [default: fast] build version
+                             <options: accurate|fast>
+  --notes=<value>            notes about the build
+  --yaml                     output raw data in YAML format
+
+DESCRIPTION
+  build a project
+
+  Use this command to build a project.
+
+EXAMPLES
+  Build a project to create models for nlu and asr using locale en-US
+
+  $ mix projects:build -L en-US -P 1922 --build-type asr --build-type nlu --nlu-model-type fast --notes "Our first build"
+```
+
+_See code: [src/commands/projects/build.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/build.ts)_
+
+## `mix projects:configure`
+
+configure a project
+
+```
+USAGE
+  $ mix projects:configure --data-pack <value> -P <value> [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --data-pack=<value>    (required) data pack name, including version (use aa-AA@x.y.z format)
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  configure a project
+
+  Use this command to update the data pack for a locale used in a project.
+  The operation is not carried out immediately. Instead, the Mix backend returns
+  a job ID that can be used to monitor progress. mix-cli outputs detailed
+  information on the created job when the 'json' flag is provided.
+
+  Note that you cannot add a new locale with this command.
+
+
+EXAMPLES
+  $ mix projects:configure -P 1922 --data-pack en-US@4.7.0
+```
+
+_See code: [src/commands/projects/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/configure.ts)_
+
+## `mix projects:create`
+
+create a new project
+
+```
+USAGE
+  $ mix projects:create -c <value> -L <value> -m <value> -n <value> -O <value> -t <value> [--child-data-compliant]
+    [--description <value>] [--engine-pack <value>] [--json |  | --yaml]
+
+FLAGS
+  -L, --locale=<value>...     (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -O, --organization=<value>  (required) organization ID (defaults to MIX_ORGANIZATION)
+  -c, --channel=<value>...    (required) channel
+  -m, --modes=<value>...      (required) channel modes (audioscript|dtmf|interactivity|richtext|tts)
+  -n, --name=<value>          (required) project name
+  -t, --topic=<value>         (required) data pack topic, e.g. 'gen'
+  --child-data-compliant      marks projects as being child-data compliant
+  --description=<value>       project description (for child data compliance)
+  --engine-pack=<value>       engine pack ID (UUID format)
+  --json                      output raw data in JSON format
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  create a new project
+
+  Use this command to create a new project. Many parameters are needed to
+  create a project. In particular, channels and modes go hand in hand. A 'channel'
+  flag must be matched by a 'modes' flag. Use a comma-separated list (no spaces)
+  of mode names to specify multiple modes for a channel.
+
+  Given the right user permissions, it is possible to specify an engine pack using
+  the 'engine-pack' flag.
+
+  Nuance’s Child Data Policy
+  Nuance’s Child Data Policy is related to online services that are subject to
+  applicable child data privacy laws, such as, but not limited to, the Children’s
+  Online Privacy Protection Act (COPPA) and Article 8 of GDPR. Nuance’s Child
+  Data Policy prohibits providing hosted services to websites or online services
+  that are primarily directed towards children under the age of 16.
+
+  When you create a project, you are required to acknowledge whether or not the
+  builds for this project will be used in an application that is deployed in a
+  Nuance hosted service in connection with an online site, service, application
+  or product that is primarily directed to children under 16.
+
+  This acknowledgement must be completed for any projects that are intended
+  for use in the Nuance SaaS cloud.
+
+  To acknowledge such a project, use the 'child-data-compliant' flag and also
+  provide a description of your project using the 'description' flag.
+
+EXAMPLES
+  Create a project with one channel and two modes
+
+  $ mix projects:create -c Channel1 -L en-US -m "dtmf,tts" -O 64 -t gen -n "ACME Project"
+
+
+
+  Create a project with two channels: one with two modes, the other with a single mode
+
+  $ mix projects:create -c Channel1 -L en-US -m "dtmf,tts" -c Channel2 -m interactivity \
+
+    -O 64 -t gen -n "ACME Project"
+
+
+
+  Create a child-data-compliant project
+
+  $ mix projects:create -c Channel1 -L en-US -m "dtmf,tts" -O 64 -t gen -n "ACME Project" \
+
+    --child-data-compliant --description "ACME project description"
+
+
+
+  Create a project with a specific engine-pack
+
+  $ mix projects:create -c Channel1 -L en-US -m "dtmf,tts" -O 64 -t gen \
+
+    -n "ACME Project" --engine-pack 995f6e23-07ff-4f89-9e42-97d0398da7fc
+```
+
+_See code: [src/commands/projects/create.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/create.ts)_
+
+## `mix projects:destroy`
+
+destroy a project
+
+```
+USAGE
+  $ mix projects:destroy -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --json                 output raw data in JSON format
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  destroy a project
+
+  Use this command to permanently delete a specific project.
+  Unless a backup exists, there is no way to restore a project that
+  has been destroyed.
+
+  The deletion needs to be confirmed by re-typing the project ID when prompted.
+  It can also be pre-confirmed by using the 'confirm' flag.
+
+EXAMPLES
+  Destroy a project
+
+  $ mix projects:destroy -P 1922
+
+
+
+  Destroy a project and provide automatic confirmation
+
+  $ mix projects:destroy -P 1922 -c 1922
+```
+
+_See code: [src/commands/projects/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/destroy.ts)_
+
+## `mix projects:export`
+
+export project package
+
+```
+USAGE
+  $ mix projects:export -P <value> [-f <value>] [--metadata-only] [--overwrite]
+
+FLAGS
+  -P, --project=<value>   (required) project ID (defaults to MIX_PROJECT)
+  -f, --filepath=<value>  output file path (defaults to "project-<projectId>.zip")
+  --metadata-only         export project metadata JSON file only
+  --overwrite             overwrite output file if it exists
+
+DESCRIPTION
+  export project package
+
+  Use this command to export the project package to a zip file.
+
+  Note that the grammar, transformation, and pronunciation files are restricted
+  to Nuance Professional Services users and not available to all users.
+  As such, the project package exported by regular users will not include
+  these files. Regular users may end up with an incomplete project after calling
+  this endpoint.
+
+  Use the 'metadata-only' flag to export the project metadata JSON file only.
+
+EXAMPLES
+  Export the project package to a zip file
+
+  $ mix projects:export -P 29050 --overwrite
+
+
+
+  Export the projecte metadata JSON file only
+
+  $ mix projects:export -P 29050 --metadata-only --overwrite
+```
+
+_See code: [src/commands/projects/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/export.ts)_
+
+## `mix projects:get`
+
+get details about a project
+
+```
+USAGE
+  $ mix projects:get -P <value> [--columns <value>  [--table channels|data-packs|project ]] [--no-header | [--json
+    | --csv | --yaml] | ] [--no-truncate |  |  | ] [--sort <value>]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --columns=<value>      only show provided columns (comma-separated) (with 'csv' flag only)
+  --csv                  output to csv format (with 'table' flag only)
+  --json                 output raw data in JSON format
+  --no-header            hide table header from output
+  --no-truncate          do not truncate output to fit screen
+  --sort=<value>         property to sort by (prepend '-' for descending)
+  --table=<option>       data table to output (with 'csv' flag only)
+                         <options: channels|data-packs|project>
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  get details about a project
+
+  Use this command to get details about a particular project.
+
+  CSV output is available for this command but only for one section of project
+  information at a time. The chosen section is specifed using the 'table' flag.
+
+EXAMPLES
+  $ mix projects:get -P 1922
+```
+
+_See code: [src/commands/projects/get.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/get.ts)_
+
+## `mix projects:list`
+
+list projects
+
+```
+USAGE
+  $ mix projects:list [--include-features] [--exclude-channels] [-O <value>] [--limit <value>] [--offset <value>]
+    [--sort <value>] [--columns <value> |  | [--json | --csv | --yaml] | ] [--filter <value> |  | ] [--no-header |  | ]
+    [--no-truncate |  |  | ] [--with-name <value>]
+
+FLAGS
+  -O, --organization=<value>  organization ID (defaults to MIX_ORGANIZATION)
+  --columns=<value>           only show provided columns (comma-separated)
+  --csv                       output to csv format
+  --exclude-channels          exclude project channels from the list
+  --filter=<value>            filter property by partial string matching, ex: name=foo
+  --include-features          include the list of features supported by project's engine pack
+  --json                      output raw data in JSON format
+  --limit=<value>             limit maximum results returned (defaults to Mix API behavior)
+  --no-header                 hide table header from output
+  --no-truncate               do not truncate output to fit screen
+  --offset=<value>            to exclude e.g., the first 10 (sorted) results, set --offset=10
+  --sort=<value>              comma-separated properties to sort by (prepend '+'/'-' for ascending/descending)
+  --with-name=<value>         filter results by project name (case sensitive)
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list projects
+
+  Use this command to list projects across all organizations.
+  A number of flags can be used to constrain the returned results.
+
+EXAMPLES
+  List projects to which you have access, across all organizations
+
+  $ mix projects:list
+
+
+
+  List projects that are part of a particular organization
+
+  $ mix projects:list -O 64
+```
+
+_See code: [src/commands/projects/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/list.ts)_
+
+## `mix projects:lock`
+
+lock a project
+
+```
+USAGE
+  $ mix projects:lock -P <value> --notes <value> [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --notes=<value>        (required) project lock notes
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  lock a project
+
+  Use this command to lock a project.
+  A project cannot be edited while it is locked.
+
+EXAMPLES
+  Lock a project with project lock notes
+
+  $ mix projects:lock -P 1922 --notes="Project lock notes"
+```
+
+_See code: [src/commands/projects/lock.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/lock.ts)_
+
+## `mix projects:rename`
+
+rename a project
+
+```
+USAGE
+  $ mix projects:rename --new-name <value> -P <value> [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+  --json                 output raw data in JSON format
+  --new-name=<value>     (required) new project name
+  --yaml                 output raw data in YAML format
+
+DESCRIPTION
+  rename a project
+
+  Use this command to rename a project.
+
+EXAMPLES
+  $ mix projects:rename -P 1922 --new-name ACME
+```
+
+_See code: [src/commands/projects/rename.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/rename.ts)_
+
+## `mix projects:replace`
+
+replace the content of a project
+
+```
+USAGE
+  $ mix projects:replace -f <value> -P <value> [-c <value>] [--json |  | --yaml]
+
+FLAGS
+  -P, --project=<value>   (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>   skip confirmation prompt by pre-supplying value
+  -f, --filepath=<value>  (required) input file path
+  --json                  output raw data in JSON format
+  --yaml                  output raw data in YAML format
+
+DESCRIPTION
+  replace the content of a project
+
+  Use this command to replace the project content with the .zip file provided.
+
+  It is recommended to use the projects:export command to create a backup of
+  the project before using the projects:replace command.
+
+  Note that the grammar, transformation, and pronunciation files are restricted
+  to users with the required permissions. Attempting to replace the content of
+  a project that contains grammar, transformation, and pronunciation files
+  without the permissions needed to provide all the expected files may result
+  in an incomplete project.
+
+EXAMPLES
+  Replace the content of a project
+
+  $ mix projects:replace -P 29050 -f myProject.zip
+
+
+
+  Replace the content of a project using pre-confirmation
+
+  $ mix projects:replace -P 29050 -f myProject.zip -c 29050
+```
+
+_See code: [src/commands/projects/replace.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/replace.ts)_
+
+## `mix projects:unlock`
+
+unlock a project
+
+```
+USAGE
+  $ mix projects:unlock -P <value>
+
+FLAGS
+  -P, --project=<value>  (required) project ID (defaults to MIX_PROJECT)
+
+DESCRIPTION
+  unlock a project
+
+  Use this command to unlock a project.
+  A project cannot be edited while it is locked.
+
+EXAMPLES
+  Unlock a project
+
+  $ mix projects:unlock -P 1922"
+```
+
+_See code: [src/commands/projects/unlock.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/projects/unlock.ts)_
+
+## `mix samples:export`
+
+export sample sentences
+
+```
+USAGE
+  $ mix samples:export -P <value> -I <value> -L <value> [-f <value>] [--overwrite]
+
+FLAGS
+  -I, --intent-name=<value>  (required) intent name
+  -L, --locale=<value>...    (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -P, --project=<value>      (required) project ID (defaults to MIX_PROJECT)
+  -f, --filepath=<value>     output file path (defaults to "samples-<projectId>-<intent>-<locale>.zip")
+  --overwrite                overwrite output file if it exists
+
+DESCRIPTION
+  export sample sentences
+
+  Use this command to export samples for an intent in the project.
+
+EXAMPLES
+  $ mix samples:export -P 29050 -I ORDER_DRINK -L en-US --overwrite
+```
+
+_See code: [src/commands/samples/export.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/samples/export.ts)_
+
+## `mix samples:import`
+
+import sample sentences, appending to existing samples by default
+
+```
+USAGE
+  $ mix samples:import -f <value> -I <value> -L <value> -P <value> [-c <value>] [--json |  | --yaml] [--replace]
+
+FLAGS
+  -I, --intent-name=<value>  (required) intent name
+  -L, --locale=<value>       (required) locale code; use format 'aa-AA' (defaults to MIX_LOCALE)
+  -P, --project=<value>      (required) project ID (defaults to MIX_PROJECT)
+  -c, --confirm=<value>      skip confirmation prompt by pre-supplying value
+  -f, --filepath=<value>     (required) input file path
+  --json                     output raw data in JSON format
+  --replace                  replace, rather than append, existing samples
+  --yaml                     output raw data in YAML format
+
+DESCRIPTION
+  import sample sentences, appending to existing samples by default
+
+  Use this command sample sentences into a project.  By default, the samples
+  sentences are appended to the project in the specified locale. It is also
+  possible to completely replace sample sentences for the specified locale
+  by using the 'replace' flag.
+
+  The import needs to be confirmed by re-typing the intent name when prompted.
+  It can also be pre-confirmed by using the 'confirm' flag. Consider making
+  a project backup before using this command.
+
+EXAMPLES
+  Import samples by appending
+
+  $ mix samples:import -P 29050 -I ORDER_DRINK -L en-US -f samples.trsx
+
+
+
+  Import samples by appending using pre-confirmation
+
+  $ mix samples:import -P 29050 -I ORDER_DRINK -L en-US -f samples.trsx -c ORDER_DRINK
+
+
+
+  Import samples by replacing
+
+  $ mix samples:import -P 29050 -I ORDER_DRINK -L en-US -f samples.trsx --replace
+
+
+
+  Import samples by replacing using pre-confirmation
+
+  $mix samples:import -P 29050 -I ORDER_DRINK -L en-US -f samples.trsx --replace -c ORDER_DRINK
+```
+
+_See code: [src/commands/samples/import.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/samples/import.ts)_
+
+## `mix system:list`
+
+list configured Mix systems
+
+```
+USAGE
+  $ mix system:list
+
+DESCRIPTION
+  list configured Mix systems
+
+  Use this command to list the Mix systems you have configured
+  to use with mix-cli.
+
+ALIASES
+  $ mix systems:list
+  $ mix system:list
+
+EXAMPLES
+  list configured Mix systens
+
+  $ mix system:list
+
+  Equivalent command
+
+  $ mix systems:list
+```
+
+_See code: [src/commands/system/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/system/list.ts)_
+
+## `mix system:version`
+
+list Mix API version and environment
+
+```
+USAGE
+  $ mix system:version [--columns <value> |  | [--json | --csv | --yaml] | ] [--no-header |  | ] [--no-truncate |  |
+    | ]
+
+FLAGS
+  --columns=<value>  only show provided columns (comma-separated)
+  --csv              output to csv format
+  --json             output raw data in JSON format
+  --no-header        hide table header from output
+  --no-truncate      do not truncate output to fit screen
+  --yaml             output raw data in YAML format
+
+DESCRIPTION
+  list Mix API version and environment
+
+  Use this command to list Mix APi version and environment information.
+
+EXAMPLES
+  $ mix system:version
+```
+
+_See code: [src/commands/system/version.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/system/version.ts)_
+
+## `mix systems:list`
+
+list configured Mix systems
+
+```
+USAGE
+  $ mix systems:list
+
+DESCRIPTION
+  list configured Mix systems
+
+  Use this command to list the Mix systems you have configured
+  to use with mix-cli.
+
+ALIASES
+  $ mix systems:list
+  $ mix system:list
+
+EXAMPLES
+  list configured Mix systens
+
+  $ mix system:list
+
+  Equivalent command
+
+  $ mix systems:list
+```
+
+## `mix voices:list`
+
+list voices in an organization
+
+```
+USAGE
+  $ mix voices:list -O <value> [--json |  | --yaml]
+
+FLAGS
+  -O, --organization=<value>  (required) organization ID (defaults to MIX_ORGANIZATION)
+  --json                      output raw data in JSON format
+  --yaml                      output raw data in YAML format
+
+DESCRIPTION
+  list voices in an organization
+
+  Use this command to list the voices in an organization.
+  The organization ID can be retrieved using the organizations:list command.
+  A number of flags can be used to constrain the returned results.
+
+EXAMPLES
+  $ mix voices:list -O 610
+```
+
+_See code: [src/commands/voices/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/voices/list.ts)_
 <!-- commandsstop -->
 
 .

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ macOS systems and under `%LOCALAPPDATA%\@nuance-mix\mix-cli\` on Windows systems
 configuration is stored in a file named "config.json" that is accessible only to
 the user who executed the `init` command.
 
+## Using mix-cli with multiple Mix systems
+When you run the `init` command, `mix-cli` detects the name of the Mix system by parsing
+the hostname provided for the Mix API server. It suggests this name as an answer
+when it prompts you for the "Mix system name".
+
+Say you have initially run the `init` command to configure mix-cli for the "us" Mix system.
+You can run the `init` command a second time to configure the "eu" system using the relevant
+hostnames. `mix-cli` stores the configuration of both systems.
+
+You can then type `mix auth --system us` to switch to and authenticate with the "us" Mix
+system. Similarly, typing `mix auth --system eu` does the same but with the "eu" Mix system.
+`mix-cli` remembers the last Mix system it authenticated with so using `mix auth` with the
+`system` flag is only needed when switching to a different Mix system.
+
+Finally, all `mix-cli` commands complete their human-readable output by reporting
+which Mix system the command was executed against.
+
 ## Overriding the central configuration
 Configuration elements can be overriden by using the following environment
 variables:

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ See our [Contribution Guidelines](CONTRIBUTING.md).
 * [`mix entities:list`](#mix-entitieslist)
 * [`mix entities:rename`](#mix-entitiesrename)
 * [`mix entity-types:list`](#mix-entity-typeslist)
+* [`mix env-configs:configure`](#mix-env-configsconfigure)
+* [`mix env-configs:destroy`](#mix-env-configsdestroy)
 * [`mix env-configs:list`](#mix-env-configslist)
 * [`mix environments:list`](#mix-environmentslist)
 * [`mix geographies:list`](#mix-geographieslist)
@@ -1927,6 +1929,97 @@ EXAMPLES
 
 _See code: [src/commands/entity-types/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/entity-types/list.ts)_
 
+## `mix env-configs:configure`
+
+configure an environment configuration
+
+```
+USAGE
+  $ mix env-configs:configure -P <value> --label <value> --value <value> [--env <value> --env-geo <value>]
+
+FLAGS
+  -P, --project=<value>  (required) project ID
+  --env=<value>          environment ID
+  --env-geo=<value>      environment-geography ID
+  --label=<value>        (required) environment configuration name
+  --value=<value>        (required) environment configuration value
+
+DESCRIPTION
+  configure an environment configuration
+
+  Environment configurations provide default values either for the project as a whole
+  or for a specific environment geography. If an environment geography doest not have
+  a default for a specific configuration, then the default for the project is used.
+
+  Using this command with only the 'project' flag configures the project-level default value
+  for the given configuration label. Using this command with the 'env' and 'env-geo' flags
+  in addition to the 'project' flag configures the default value for the given configuration
+  label targeting the specified environment geography.
+
+  Passing an empty string as the value will unset the configuration.
+
+
+EXAMPLES
+  Configure an environment configuration project default
+
+  $ mix env-configs:configure -P 1922 --label=GRAMMAR_BASE_PATH --value=https://www.example.com/grammars
+
+  Configure an environment configuration for a specific environment geography
+
+  $ mix env-configs:configure -P 1922 --env=1923 --env-geo=9 --label=GRAMMAR_BASE_PATH --value=https://www.example.com/grammars
+
+  Unset an environment configuration project default
+
+  $ mix env-configs:configure -P 1922 --label=GRAMMAR_BASE_PATH --value=""
+```
+
+_See code: [src/commands/env-configs/configure.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/env-configs/configure.ts)_
+
+## `mix env-configs:destroy`
+
+destroy an environment configuration
+
+```
+USAGE
+  $ mix env-configs:destroy -P <value> --label <value> [--env <value> --env-geo <value>] [-c <value>]
+
+FLAGS
+  -P, --project=<value>  (required) project ID
+  -c, --confirm=<value>  skip confirmation prompt by pre-supplying value
+  --env=<value>          environment ID
+  --env-geo=<value>      environment-geography ID
+  --label=<value>        (required) environment configuration name
+
+DESCRIPTION
+  destroy an environment configuration
+
+  Environment configurations provide default values either for the project as a whole
+  or for a specific environment geography. If an environment geography doest not have
+  a default for a specific configuration, then the default for the project is used.
+
+  Using this command with only the 'project' flag deletes the project-level default value
+  for the given configuration label. Using this command with the 'env' and 'env-geo' flags
+  in addition to the 'project' flag deletes the default value for the given configuration
+  label targeting the specified environment geography.
+
+
+
+EXAMPLES
+  Destroy an environment configuration project default
+
+  $ mix env-configs:destroy -P 1922 --label GRAMMAR_BASE_PATH
+
+  Destroy an environment configuration for a specific environment geography
+
+  $ mix env-configs:destroy -P 1922 --env=1923 --env-geo=9 --label=GRAMMAR_BASE_PATH
+
+  Destroy an environment configuration project default and provide automatic confirmation
+
+  $ mix env-configs:destroy -P 1922 --label GRAMMAR_BASE_PATH --confirm GRAMMAR_BASE_PATH
+```
+
+_See code: [src/commands/env-configs/destroy.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/env-configs/destroy.ts)_
+
 ## `mix env-configs:list`
 
 list environment configurations
@@ -1954,7 +2047,7 @@ DESCRIPTION
 EXAMPLES
   List environment configurations for project ID 29050
 
-  $ mix projects:list -P 29050
+  $ mix env-configs:list -P 29050
 ```
 
 _See code: [src/commands/env-configs/list.ts](https://github.com/nuance-communications/mix-cli/blob/v0.0.0-semantically-released/src/commands/env-configs/list.ts)_

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -18,8 +18,9 @@ import {Config, MixCLIConfig} from '../utils/config'
 import {configurationProblemExitCode, tokenFileName} from '../utils/constants'
 
 const SUCCESS = 'Token was retrieved and stored successfully.\n' +
-  'You are now ready to use mix-cli! 🚀\n\n' +
-  'If you are a first time user, you can start by looking\n' +
+  'You are now ready to use mix-cli! 🚀'
+
+const SUCCESS_NEW_USER = 'If you are a first time user, you can start by looking\n' +
   'at the organizations you are part of by typing:\n\n' +
   'mix organizations:list\n\n' +
   'Your organization ID is needed for a number of mix commands.'
@@ -32,8 +33,9 @@ Use this command to retrieve an access token. Once mix-cli has acquired the
 access token, it takes care of refreshing it automatically.
 
 Use the 'system' flag to authenticate with a specific Mix system. mix-cli executes
-commands against the last Mix system it successfully authenticated against.
-Run the 'auth' command again to switch to a different Mix system.`
+commands against the last Mix system it successfully authenticated with.
+
+Run the 'system:list' command to see your list of configured Mix systems.`
 
   static examples = [
     'Authenticate with last Mix system used',
@@ -150,6 +152,11 @@ that configuration file swiftly.`)
       })
     } else {
       this.log(SUCCESS)
+
+      if (!this.mixCLIConfig.systems) {
+        this.log()
+        this.log(SUCCESS_NEW_USER)
+      }
     }
   }
 }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -114,6 +114,9 @@ Run the 'system:list' command to see your list of configured Mix systems.`
     debug('run()')
     try {
       this.mixCLIConfig = Config.getMixCLIConfig(this.config)
+      if (Config.isOldConfig(this.mixCLIConfig)) {
+        this.handleOldConfig()
+      }
     } catch {
       this.log(`
 mix-cli now requires a central configuration file.
@@ -139,10 +142,8 @@ that configuration file swiftly.`)
           ],
         }
       }
-    } else if (this.mixCLIConfig.currentSystem) {
-      this.log(`Authenticating with ${chalk.green(this.mixCLIConfig.currentSystem)} Mix system`)
     } else {
-      this.log(`Authenticating with authServer: ${chalk.green(this.mixCLIConfig.authServer)}`)
+      this.log(`Authenticating with ${chalk.green(this.mixCLIConfig.currentSystem)} Mix system`)
     }
 
     await this.runWithClientCredentialsGrant()

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -40,7 +40,6 @@ Run the 'system:list' command to see your list of configured Mix systems.`
   static examples = [
     'Authenticate with last Mix system used',
     '$ mix auth',
-    '',
     'Authenticate with and switch to the "us" Mix system',
     '$ mix auth --system us',
   ]

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -66,6 +66,9 @@ Run the 'system:list' command to see your list of configured Mix systems.`
     const {authServer, clientId, clientSecret, scope} = this.mixCLIConfig!
 
     CliUx.ux.action.start('Retrieving access token using Client Credentials Grant')
+    if (this.authError) {
+      CliUx.ux.action.stop(chalk.red('failed'))
+    }
 
     const authServerAndCreds: AuthServerAndCreds = {
       authServerHost: authServer,
@@ -133,6 +136,7 @@ that configuration file swiftly.`)
           message: `Failed to switch to Mix system: ${error.message}`,
           suggestions: [
             'Verify the value provided for system.',
+            'Use "mix init" to add a new system to your configuration.',
           ],
         }
       }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -135,9 +135,9 @@ that configuration file swiftly.`)
         }
       }
     } else if (this.mixCLIConfig.currentSystem) {
-      this.log(`Authenticating with Mix system: ${chalk.green(this.mixCLIConfig.currentSystem)}`)
+      this.log(`Authenticating with ${chalk.green(this.mixCLIConfig.currentSystem)} Mix system`)
     } else {
-      this.log('Authenticating with last used Mix system')
+      this.log(`Authenticating with authServer: ${chalk.green(this.mixCLIConfig.authServer)}`)
     }
 
     await this.runWithClientCredentialsGrant()

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -76,18 +76,21 @@ configuration can also be overridden using environment variables.`
       this.log() // intentional blank line
     }
 
-    let oldConfig : MixCLIConfig | undefined
+    let currentConfig : MixCLIConfig | undefined
     // Do we have a previous configuration to back up?
     if (isMixCLIConfigPresent) {
       const config = Config.getMixCLIConfig(this.config)
-      oldConfig = Config.isOldConfig(config) ? Config.convertOldConfigToNew(config) : config
+      currentConfig = Config.isOldConfig(config) ? Config.convertOldConfigToNew(config) : config
 
       const backupPathName = Config.moveMixCLIConfigToBackup(configDir)
       this.outputMixCLIConfigurationBackedUp(backupPathName)
     }
 
     // Store new configuration to file
-    const combinedConfig = Config.combineConfigs(mixCLIConfig, oldConfig)
+    const combinedConfig = Config.combineConfigSystems({
+      newConfig: mixCLIConfig,
+      oldConfig: currentConfig,
+    })
     const configStoreErrorMessage = Config.storeMixCLIConfig(configDir, combinedConfig)
     if (configStoreErrorMessage) {
       this.error(configStoreErrorMessage)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -240,7 +240,8 @@ and consistent set of configuration values.`)
     this.log()
     this.log('Next, you can:')
     this.log(`  - get authenticated by typing: ${chalk.cyan('mix auth')}`)
-    this.log(`  - get the list of configured Mix systems by typing: ${chalk.cyan('mix system:list')}`)
+    this.log(`  - see your list of configured Mix systems by typing: ${chalk.cyan('mix system:list')}`)
+    this.log(`  - switch to a different Mix system by typing: ${chalk.cyan('mix auth --system <system name>')}`)
   }
 
   outputVerifyEnvironmentVariables() {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -47,7 +47,6 @@ configuration can also be overridden using environment variables.`
 
     // Do we already have a central configuration file?
     if (isMixCLIConfigPresent) {
-      // this.warnAboutOverwritingConfiguration(mixCLIConfigFilePath)
       this.outputAnswerSomeQuestions()
     } else if (isAnyMixCLIEnvVariablePresent) { // Do we have environment variables to worry about?
       if (isMixCLIEnvVariableSetComplete) {
@@ -252,15 +251,5 @@ and consistent set of configuration values.`)
     this.log(`
 ${chalk.yellow('Note')}: You have Mix environment variables set currently.
 Verify them as they take precedence over the central configuration file.`)
-  }
-
-  warnAboutOverwritingConfiguration(mixCLIConfigFilePath: string) {
-    debug('warnAboutOverwritingConfiguration(')
-    this.log(`
-${chalk.yellow('Note')}: A configuration file already exists in:
-${mixCLIConfigFilePath}
-
-It will be backed up before the new configuration file gets created, after you answer the
-question(s) that follow. You can use ${chalk.cyan('CTRL-C')} to exit the 'init' command.`)
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -119,7 +119,7 @@ configuration can also be overridden using environment variables.`
     const clientSecret = await CliUx.ux.prompt('Your client secret?',
       {type: 'hide'})
     const suggestedSystem = Config.getSystemFromApiServer(apiServer)
-    const system = await CliUx.ux.prompt('System name?',
+    const system = await CliUx.ux.prompt('Mix system name?',
       {default: suggestedSystem})
 
     const values = {
@@ -186,7 +186,7 @@ configuration can also be overridden using environment variables.`
     debug('outputAnswerSomeQuestions()')
     this.log(`
 Answer the few questions below to configure mix-cli.
-Simply accept defaults if you plan on using the Production US environment.`)
+Simply accept defaults if you plan on using the Production US Mix system ("us").`)
   }
 
   outputCanUseEnvironmentVariables() {
@@ -219,7 +219,7 @@ and consistent set of configuration values.`)
 
   outputLetsCreateNewConfig() {
     debug('outputLetsCreateNewConfig()')
-    this.log('Let\'s create a new configuration file for mix-cli.')
+    this.log('Let\'s configure a Mix system for mix-cli to use.')
   }
 
   outputMixCLIConfigurationBackedUp(backupPathName: string) {
@@ -235,9 +235,12 @@ and consistent set of configuration values.`)
 
   outputUserIsAllSet() {
     debug('outputUserIsAllSet()')
-    this.log(`\nYour mix-cli configuration is ready! Next, get authenticated by typing:
-
-mix auth`)
+    this.log()
+    this.log('Your mix-cli configuration is ready!')
+    this.log()
+    this.log('Next, you can:')
+    this.log(`  - get authenticated by typing: ${chalk.cyan('mix auth')}`)
+    this.log(`  - get the list of configured Mix systems by typing: ${chalk.cyan('mix system:list')}`)
   }
 
   outputVerifyEnvironmentVariables() {

--- a/src/commands/system/list.ts
+++ b/src/commands/system/list.ts
@@ -48,12 +48,8 @@ export default class SystemVersionList extends BaseCommand {
     }
 
     this.mixCLIConfig = config
-    if (!config.systems) {
-      this.log(chalk.yellow('Old configuration file detected'))
-      CliUx.ux.action.start('Upgrading configuration file')
-      this.mixCLIConfig = Config.convertOldConfigToNew(this.mixCLIConfig!)
-      this.writeConfigToDisk()
-      CliUx.ux.action.stop(chalk.green('done'))
+    if (Config.isOldConfig(config)) {
+      this.handleOldConfig()
     }
 
     this.log(chalk.bold('Configured Mix systems:'))

--- a/src/commands/system/list.ts
+++ b/src/commands/system/list.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022, Nuance, Inc. and its contributors.
+ * All rights reserved.
+ *
+ * This source code is licensed under the Apache-2.0 license found in
+ * the LICENSE file in the root directory of this source tree.
+ */
+
+import chalk from 'chalk'
+import makeDebug from 'debug'
+import {Config} from '../../utils/config'
+import {CliUx, Command} from '@oclif/core'
+
+const debug = makeDebug('mix:commands:system:list')
+
+export default class SystemVersionList extends Command {
+  static description = `list configured Mix systems
+  
+  Use this command to list the Mix systems you have configured
+  to use with mix-cli.`
+
+  static examples = ['mix system:list']
+
+  static aliases = ['systems:list']
+  get columns() {
+    return {
+      systemName: {header: 'System'},
+      apiServer: {header: 'APIServer'},
+      authServer: {header: 'AuthServer'},
+      scope: {header: 'Scope'},
+      tenant: {header: 'Tenant'},
+    }
+  }
+
+  async run() {
+    debug('run()')
+    this.log(chalk.bold('Configured Mix systems:'))
+    this.log()
+    const {systems} = Config.getMixCLIConfig(this.config)
+    const systemsTable = []
+    for (const [name, config] of Object.entries(systems!)) {
+      systemsTable.push({
+        systemName: name,
+        apiServer: config.apiServer,
+        authServer: config.authServer,
+        scope: config.scope,
+        tenant: config.tenant,
+      })
+    }
+
+    CliUx.ux.table(systemsTable, this.columns, {})
+    this.log()
+    this.log(`To switch to a different Mix system, run: ${chalk.cyan('mix auth --system <system>')}`)
+    this.log(`To add a new Mix system to your configuration, run: ${chalk.cyan('mix init')}`)
+  }
+}

--- a/src/commands/system/list.ts
+++ b/src/commands/system/list.ts
@@ -19,9 +19,15 @@ export default class SystemVersionList extends Command {
   Use this command to list the Mix systems you have configured
   to use with mix-cli.`
 
-  static examples = ['mix system:list']
+  static examples = [
+    'list configured Mix systens',
+    'mix system:list',
+    'Equivalent command',
+    'mix systems:list',
+  ]
 
-  static aliases = ['systems:list']
+  static aliases = ['systems:list', 'system:list']
+
   get columns() {
     return {
       systemName: {header: 'System'},

--- a/src/commands/system/list.ts
+++ b/src/commands/system/list.ts
@@ -68,7 +68,11 @@ export default class SystemVersionList extends BaseCommand {
 
     CliUx.ux.table(systemsTable, this.columns, {})
     this.log()
-    this.log(`To switch to a different Mix system, run: ${chalk.cyan('mix auth --system <system>')}`)
+
+    if (Object.keys(systems!).length > 1) {
+      this.log(`To switch to a different Mix system, run: ${chalk.cyan('mix auth --system <system>')}`)
+    }
+
     this.log(`To add a new Mix system to your configuration, run: ${chalk.cyan('mix init')}`)
   }
 }

--- a/src/commands/system/version.ts
+++ b/src/commands/system/version.ts
@@ -62,11 +62,11 @@ export default class SystemVersion extends MixCommand {
     const mixCLIConfig = Config.getMixCLIConfig()
     const mixAPIServer = mixCLIConfig.apiServer
 
-    return this.log(
-      `Mix API server ${chalk.cyan(mixAPIServer)}` +
-        `\nrunning API version ${chalk.cyan(apiVersion)}` +
-        `\nin environment ${chalk.cyan(mixEnvironment)}` +
-        ` on Mix version ${chalk.cyan(mixVersion)}`)
+    this.log()
+    this.log(`Mix API server ${chalk.cyan(mixAPIServer)}`)
+    this.log(`running API version ${chalk.cyan(apiVersion)}`)
+    this.log(`in environment ${chalk.cyan(mixEnvironment)}`)
+    this.log(`on Mix version ${chalk.cyan(mixVersion)}`)
   }
 
   outputCSV(transformedData: any) {

--- a/src/utils/base/base-command.ts
+++ b/src/utils/base/base-command.ts
@@ -28,11 +28,7 @@ export default abstract class BaseCommand extends Command {
     const {clientId, clientSecret, ...safeToPrintConfig} = this.mixCLIConfig!
     debug('mix-cli configuration: %O', safeToPrintConfig)
     if (Config.isOldConfig(this.mixCLIConfig!)) {
-      this.log(chalk.yellow('Old configuration file detected'))
-      CliUx.ux.action.start('Upgrading configuration file')
-      this.mixCLIConfig = Config.convertOldConfigToNew(this.mixCLIConfig!)
-      this.writeConfigToDisk()
-      CliUx.ux.action.stop(chalk.green('done'))
+      this.handleOldConfig()
     }
 
     const authServerAndCreds: AuthServerAndCreds = {
@@ -108,5 +104,13 @@ export default abstract class BaseCommand extends Command {
       this.log('Failed to write to configuration file. Exiting.')
       this.error(configStoreErrorMessage)
     }
+  }
+
+  handleOldConfig() {
+    this.log(chalk.yellow('Old configuration file detected'))
+    CliUx.ux.action.start('Upgrading configuration file')
+    this.mixCLIConfig = Config.convertOldConfigToNew(this.mixCLIConfig!)
+    this.writeConfigToDisk()
+    CliUx.ux.action.stop(chalk.green('done'))
   }
 }

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -72,7 +72,7 @@ export default abstract class MixCommand extends BaseCommand {
   shouldWatchJob = false
   tries = 0
 
-  abstract doRequest(client: MixClient, params: MixRequestParams): Promise<MixResponse>
+  abstract doRequest(client: MixClient, params: MixRequestParams): Promise<MixResponse> | void
 
   async run() {
     debug('run()')
@@ -123,6 +123,10 @@ that configuration file swiftly.`)
 
     const response = await this.doSafeRequest(this.client, requestParams)
     await this.handleResponse(response)
+
+    if (!this.options.json && !this.options.csv && !this.options.yaml) {
+      this.log(`Command executed against ${chalk.green(this.mixCLIConfig?.currentSystem)} Mix system.`)
+    }
   }
 
   // ------------------------------------------------------------------------

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -61,7 +61,8 @@ export const Config = {
     }
 
     const fileConfig = config ?
-      loadMixCLIConfig(process.env.MIX_CONFIG_DIR || config.configDir) : {}
+      loadMixCLIConfig(process.env.MIX_CONFIG_DIR || config.configDir) :
+      {}
     mixCLIConfig = overrideConfigUsingEnvVars(fileConfig)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {clientId, clientSecret, ...safeToShow} = mixCLIConfig
@@ -72,7 +73,9 @@ export const Config = {
 
   getMissingEnvironmentVariables(): string[] {
     debug('getMissingEnvironmentVariables()')
-    const missingEnvVars = evNames.filter(evName => process.env[evName] === undefined)
+    const missingEnvVars = evNames.filter(
+      evName => process.env[evName] === undefined,
+    )
     return missingEnvVars
   },
 
@@ -165,14 +168,23 @@ export const Config = {
     return newConfig
   },
 
-  combineConfigs(newConfig: MixCLIConfig, oldConfig: MixCLIConfig | undefined): MixCLIConfig {
+  combineConfigSystems(payload: {
+    newConfig: MixCLIConfig | undefined;
+    oldConfig: MixCLIConfig | undefined;
+  }): MixCLIConfig {
     debug('combineConfigs()')
+    const {newConfig, oldConfig} = payload
+
+    if (!newConfig) {
+      return oldConfig!
+    }
+
     if (!oldConfig) {
       return newConfig
     }
 
     const combinedConfig = {
-      ...newConfig,
+      ...oldConfig,
       systems: {
         ...oldConfig.systems,
         ...newConfig.systems,
@@ -181,13 +193,15 @@ export const Config = {
     return combinedConfig
   },
 
-  getSystemFromApiServer(apiUrl: string) : string {
+  getSystemFromApiServer(apiUrl: string): string {
     // prod URL
     const words = apiUrl.split('.')
     if (apiUrl.startsWith('mix.api.nuance')) {
       switch (words.at(-1)) {
-        case 'com': return 'us'
-        default: return words.at(-1)!
+        case 'com':
+          return 'us'
+        default:
+          return words.at(-1)!
       }
     }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -198,6 +198,7 @@ export const Config = {
   switchConfiguration(config: MixCLIConfig, system: string): MixCLIConfig {
     const {systems} = config
     if (!systems) {
+      // should never happen
       return config
     }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -193,10 +193,10 @@ export const Config = {
     return combinedConfig
   },
 
-  getSystemFromApiServer(apiUrl: string): string {
+  getSystemFromApiServer(apiURL: string): string {
     // prod URL
-    const words = apiUrl.split('.')
-    if (apiUrl.startsWith('mix.api.nuance')) {
+    const words = apiURL.split('.')
+    if (apiURL.startsWith('mix.api.nuance')) {
       switch (words.at(-1)) {
         case 'com':
           return 'us'
@@ -206,7 +206,7 @@ export const Config = {
     }
 
     // non prod URL
-    return words[1] === 'mix' ? 'pre-prod' : words[1] ?? apiUrl
+    return words[1] === 'mix' ? 'pre-prod' : words[1] ?? apiURL
   },
 
   switchConfiguration(config: MixCLIConfig, system: string): MixCLIConfig {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -209,7 +209,7 @@ export const Config = {
       }
     }
 
-    throw new Error(`System "${system}" does not exist. Use "mix init" to add a new system to your configuration.`)
+    throw new Error(`System "${system}" does not exist.`)
   },
 }
 

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -424,6 +424,11 @@ export const sortFlag = Flags.string({
     'comma-separated properties to sort by (prepend \'+\'/\'-\' for ascending/descending)',
 })
 
+export const systemFlag = Flags.string({
+  char: 'S',
+  description: 'Mix system',
+})
+
 export const userFlag = Flags.integer({
   char: userShortcut,
   description: userDesc,

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -33,6 +33,7 @@ export const mixApplicationShortcut = 'M'
 export const organizationIDShortcut = 'O'
 export const projectShortcut = 'P'
 export const runtimeApplicationIDShortcut = 'R'
+export const systemShortcut = 'S'
 export const userShortcut = 'U'
 export const tagShortcut = 'T'
 
@@ -425,7 +426,7 @@ export const sortFlag = Flags.string({
 })
 
 export const systemFlag = Flags.string({
-  char: 'S',
+  char: systemShortcut,
   description: 'Mix system',
 })
 

--- a/test/commands/env-configs/list.test.ts
+++ b/test/commands/env-configs/list.test.ts
@@ -58,7 +58,8 @@ describe("env-configs:list command", () => {
 
         // this is no project default, and 4 environments in total, so 4 rows.
         // add in the headers and the separator => 2 rows.
-        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(6);
+        // and the current mix system => 1 row.
+        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(7);
       }
     );
 
@@ -88,7 +89,8 @@ describe("env-configs:list command", () => {
 
         // this has one project default and one geography default with the same label => 1 * 4 => 4 rows.
         // add in the headers and the separator => 2 rows.
-        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(6);
+        // and the current mix system => 1 row.
+        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(7);
       }
     );
 
@@ -122,7 +124,8 @@ describe("env-configs:list command", () => {
         // there is one project default so that's 1 * 4 => 4 rows.
         // there is one geography default for a different label so that's 1 row.
         // add in the headers and the separator => 2 rows.
-        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(7);
+        // and the current mix system => 1 row.
+        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(8);
       }
     );
 
@@ -153,7 +156,8 @@ describe("env-configs:list command", () => {
 
         // there's one project default for 4 environments => 4 rows.
         // add in the headers and the separator => 2 rows.
-        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(6);
+        // and the current mix system => 1 row.
+        expect(ctx.stdout.split("\n").filter(Boolean)).to.have.lengthOf(7);
       }
     );
 

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -9,7 +9,7 @@ describe('Help message handling', () => {
     expect(ctx.stdout).to.include('projects')
     expect(ctx.stdout).to.include('manage projects')
     expect(ctx.stdout).to.include('auth')
-    expect(ctx.stdout).to.include('obtain Mix access token')
+    expect(ctx.stdout).to.include('obtain a Mix access token')
   })
 
   // we use the help subcommand instead of passing in --help to the projects:list command

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -12,13 +12,23 @@ const mixAPIServer = 'mix-api.example.com'
 
 export const mixAPIServerURL = `https://${mixAPIServer}`
 
-export const getMixCLIConfigMock = {
+const currentConfig = {
   authServer: 'auth.example.com',
   clientId: crypto.randomUUID(),
   clientSecret: crypto.randomUUID(),
   apiServer: mixAPIServer, 
   scope: 'mix-api',
   tenant: 'mix'
+}
+
+export const getMixCLIConfigMock = {
+  ...currentConfig,
+  currentSystem: 'test',
+  systems: {
+    test: {
+      ...currentConfig
+    }
+  }
 }
 
 export const oAuthMock = {


### PR DESCRIPTION
This adds support for storing and switching between different configurations(referred to as "systems")

To use, run `mix init` as usual and enter the system name when it prompts you for the same. 

To switch, you can use `mix auth`. For example, to switch to `dev`, run

```
mix auth --system dev
```