### PR TITLE
fix: upgrade axios to 1.6.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@oclif/plugin-autocomplete": "^1.3.0",
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^2.1.12",
-        "axios": "0.26.0",
+        "axios": "1.6.2",
         "chalk": "4.1.2",
         "date-fns": "2.28.0",
         "debug": "4.3.3",
@@ -4816,11 +4816,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
-      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -15781,6 +15783,11 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@oclif/plugin-autocomplete": "^1.3.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.1.12",
-    "axios": "0.26.0",
+    "axios": "1.6.2",
     "chalk": "4.1.2",
     "date-fns": "2.28.0",
     "debug": "4.3.3",

--- a/src/mix/client.ts
+++ b/src/mix/client.ts
@@ -6,7 +6,7 @@
  * the LICENSE file in the root directory of this source tree.
  */
 
-import axios, {AxiosRequestHeaders} from 'axios'
+import axios, {RawAxiosRequestHeaders} from 'axios'
 import makeDebug from 'debug'
 
 import {
@@ -52,7 +52,7 @@ export function createMixClient(options: MixClientOptions) {
         debug(`request method: ${method}`)
         debug(`request url: ${url}`)
         debug('request body: %O', data)
-        const augmentedHeaders: AxiosRequestHeaders = {
+        const augmentedHeaders: RawAxiosRequestHeaders = {
           Authorization: bearerToken,
           'User-Agent': userAgent,
           ...headers}

--- a/test/commands/grammars/replace.test.ts
+++ b/test/commands/grammars/replace.test.ts
@@ -11,7 +11,7 @@ import {expect, test} from '@oclif/test'
 import {mixAPIServerURL} from '../../mocks'
 import testData from './grammars-test-data'
 
-import * as createFormModule from '../../../src/mix/api/utils/create-form'
+import * as CreateFormModule from '../../../src/mix/api/utils/create-form'
 
 const chai = require('chai')
 const sinon = require('sinon')
@@ -25,9 +25,9 @@ const {
   grammarsReplaceResponse,
 } = testData
 
-const getHeaders = () => ({
-  'Content-Type': 'multipart/form-data; boundary=--------------------------461709635804907982362641'
-})
+const form = new FormData() as any
+form.append('file', Buffer.alloc(10))
+form.getHeaders = () => {}
 
 describe('grammars:replace command', () => {
   const projectId = '254'
@@ -35,14 +35,11 @@ describe('grammars:replace command', () => {
   const filepath = `./grammars.grxml`
   const endpoint = `/v4/projects/${projectId}/entities/${entityName}/grammars/.replace`
   const promptStub = sinon.stub()
-  const createFormStub = sinon.stub().returns({getHeaders})
+
+  const createFormStub = sinon.stub().returns(form)
 
   afterEach(() => {
     promptStub.reset()
-  })
-
-  after(() => {
-    createFormStub.reset()
   })
 
   describe('grammars:replace command with valid projectId, entityName and filepath', () => {
@@ -57,7 +54,7 @@ describe('grammars:replace command', () => {
             .post(endpoint)
             .reply(200, grammarsReplaceResponse)
         )
-        .stub(createFormModule, 'createForm', () => createFormStub(filepath))
+        .stub(CreateFormModule, 'createForm', createFormStub)
         .stdout()
         .stderr()
         .command(['grammars:replace', '-P', projectId, '-E', entityName, '-f', filepath])
@@ -88,7 +85,7 @@ describe('grammars:replace command', () => {
             .post(endpoint)
             .reply(200, grammarsReplaceResponse)
         )
-        .stub(createFormModule, 'createForm', () => createFormStub(filepath))
+        .stub(CreateFormModule, 'createForm', createFormStub)
         .stdout()
         .command(['grammars:replace',
           `-P=${projectId}`,
@@ -105,7 +102,7 @@ describe('grammars:replace command', () => {
 
       const wrongEntity = 'Drnk'
       test
-        .stub(createFormModule, 'createForm', createFormStub)
+        .stub(CreateFormModule, 'createForm', createFormStub)
         .stdout()
         .command(['grammars:replace',
           `-P=${projectId}`,

--- a/test/commands/literals/import.test.ts
+++ b/test/commands/literals/import.test.ts
@@ -27,20 +27,16 @@ const endpoints = {
   replace: `/v4/projects/1922/entities/DrinkSize/literals/.replace`,
 }
 
-const getHeaders = () => ({
-  'Content-Type': 'multipart/form-data; boundary=--------------------------461709635804907982362641'
-})
+const form = new FormData() as any
+form.append('file', Buffer.alloc(10))
+form.getHeaders = () => {}
 
 describe('literals:import command', () => {
   const promptStub = sinon.stub()
-  const createFormStub = sinon.stub().returns({getHeaders})
+  const createFormStub = sinon.stub().returns(form)
 
   afterEach(() => {
     promptStub.reset()
-  })
-
-  after(() => {
-    createFormStub.reset()
   })
 
   test

--- a/test/commands/ontology/import.test.ts
+++ b/test/commands/ontology/import.test.ts
@@ -24,20 +24,17 @@ const serverURL = `https://${testData.server}`
 
 const endpoint = `/v4/projects/1922/ontology/.append`
 
-const getHeaders = () => ({
-  'Content-Type': 'multipart/form-data; boundary=--------------------------461709635804907982362641'
-})
-
 describe('ontology:import command', () => {
   const promptStub = sinon.stub()
-  const createFormStub = sinon.stub().returns({getHeaders})
+
+  const form = new FormData() as any
+  form.append('file', Buffer.alloc(10))
+  form.getHeaders = () => {}
+
+  const createFormStub = sinon.stub().returns(form)
 
   afterEach(() => {
     promptStub.reset()
-  })
-
-  after(() => {
-    createFormStub.reset()
   })
 
   test

--- a/test/commands/projects/replace.test.ts
+++ b/test/commands/projects/replace.test.ts
@@ -24,19 +24,17 @@ const td = require('./projects-test-data')
 const testEnvData = require('../../test-data')
 const serverURL = `https://${testEnvData.server}`
 
-const getHeaders = () => ({
-  'Content-Type': 'multipart/form-data; boundary=--------------------------461709635804907982362641'
-})
+const form = new FormData() as any
+form.append('file', Buffer.alloc(10))
+form.getHeaders = () => {}
 
 describe('projects:replace', () => {
   const promptStub = sinon.stub()
-  const createFormStub = sinon.stub().returns({getHeaders})
+  const createFormStub = sinon.stub().returns(form)
 
   afterEach(() => {
     promptStub.reset()
   })
-
-  after(() => {createFormStub.reset()})
 
   test
     .env(testEnvData.env)

--- a/test/commands/samples/import.test.ts
+++ b/test/commands/samples/import.test.ts
@@ -27,20 +27,16 @@ const endpoints = {
   replace: `/v4/projects/1922/intents/ORDER_DRINK/samples/.replace`,
 }
 
-const getHeaders = () => ({
-  'Content-Type': 'multipart/form-data; boundary=--------------------------461709635804907982362641'
-})
+const form = new FormData() as any
+form.append('file', Buffer.alloc(10))
+form.getHeaders = () => {}
 
 describe('samples:import command', () => {
   const promptStub = sinon.stub()
-  const createFormStub = sinon.stub().returns({getHeaders})
+  const createFormStub = sinon.stub().returns(form)
 
   afterEach(() => {
     promptStub.reset()
-  })
-
-  after(() => {
-    createFormStub.reset()
   })
 
   test


### PR DESCRIPTION
This PR upgrades axios to 1.6.2 to address a vulnerability issue.

The type for headers had to be changed.

The axios upgrade exposed a problem with a number of unit tests. It turns out that `createForm()` was not stubbed correctly. This is addressed and all unit tests pass.