### PR TITLE
feat: add experimental support for device code authentication flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ assignment wins:
  * `.env` file in current working directory
  * environment variables already set in the execution environment 
 
+## Experimental support for Device Code authentication flow
+Experimental support for the Device Code authorization flow has been added to `mix-cli`.
+You can configure a Mix system for this authorization flow by answering "device" to the
+"Authentication flow?" question that now comes first when running the `init` command.
+
 # Retrieving the access token
 With the relevant configuration in place, you first need to retrieve an access
 token before using any of the other cli commands. Simply type:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "Apache-2.0",
       "dependencies": {
+        "@azure/msal-node": "2.6.2",
         "@oclif/core": "^1.24.3",
         "@oclif/plugin-autocomplete": "^1.3.0",
         "@oclif/plugin-help": "^5",
@@ -90,6 +91,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.6.1.tgz",
+      "integrity": "sha512-yL97p2La0WrgU3MdXThOLOpdmBMvH8J69vwQ/skOqORYwOW/UYPdp9nZpvvfBO+zFZB5M3JkqA2NKtn4GfVBHw==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.6.2.tgz",
+      "integrity": "sha512-XyP+5lUZxTpWpLCC2wAFGA9wXrUhHp1t4NLmQW0mQZzUdcSay3rG7kGGqxxeLf8mRdwoR0B70TCLmIGX6cfK/g==",
+      "dependencies": {
+        "@azure/msal-common": "14.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5040,6 +5062,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -6294,6 +6321,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.9",
@@ -9518,6 +9553,27 @@
         "node": "*"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/just-diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-5.2.0.tgz",
@@ -9535,6 +9591,25 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.3",
@@ -9674,29 +9749,52 @@
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "dev": true
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "bugs": "https://community.mix.nuance.com",
   "dependencies": {
+    "@azure/msal-node": "2.6.2",
     "@oclif/core": "^1.24.3",
     "@oclif/plugin-autocomplete": "^1.3.0",
     "@oclif/plugin-help": "^5",

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -86,7 +86,7 @@ Run the 'system:list' command to see your list of configured Mix systems.`
         message: `Failed to obtain access token: ${errorMessage}`,
         suggestions: [
           'Make sure you are using valid service credentials; default credentials will not work.',
-          'Verify your network connectivity.',
+          'Verify your network connectivity and/or VPN connection.',
           'Verify the values provided for the authentication and API servers in your configuration.',
         ],
       }

--- a/src/commands/system/list.ts
+++ b/src/commands/system/list.ts
@@ -21,7 +21,7 @@ export default class SystemVersionList extends BaseCommand {
   to use with mix-cli.`
 
   static examples = [
-    'list configured Mix systens',
+    'list configured Mix systems',
     'mix system:list',
     'Equivalent command',
     'mix systems:list',
@@ -33,7 +33,7 @@ export default class SystemVersionList extends BaseCommand {
     return {
       systemName: {header: 'System'},
       apiServer: {header: 'APIServer'},
-      authServer: {header: 'AuthServer'},
+      authServer: {header: 'AuthServer/AuthorityURL'},
       scope: {header: 'Scope'},
       tenant: {header: 'Tenant'},
     }
@@ -68,6 +68,10 @@ export default class SystemVersionList extends BaseCommand {
 
     CliUx.ux.table(systemsTable, this.columns, {})
     this.log()
+
+    if (config.currentSystem) {
+      this.log(`Current Mix system: ${chalk.cyan(config.currentSystem)}`)
+    }
 
     if (Object.keys(systems!).length > 1) {
       this.log(`To switch to a different Mix system, run: ${chalk.cyan('mix auth --system <system>')}`)

--- a/src/mix/api/system.ts
+++ b/src/mix/api/system.ts
@@ -21,6 +21,7 @@ const debug = makeDebug('mix:api:system')
  */
 export async function getSystemVersion(client: MixClient, _requestParams: SystemVersionParams = {}): Promise<MixResponse> {
   debug('getSystemVersion()')
+
   return client.request({
     method: 'get',
     url: buildURL(client.getServer(), '/v4/version'),

--- a/src/mix/api/utils/build-url.ts
+++ b/src/mix/api/utils/build-url.ts
@@ -9,9 +9,9 @@
 /* eslint-disable unicorn/prefer-node-protocol */
 import {URL} from 'url'
 
-import {MixRequestSearchParams} from '../../types'
+import {MixRequestSearchParams, ServerInfo} from '../../types'
 
-export default function buildURL(server: string, path: string, params?: MixRequestSearchParams): URL {
+export default function buildURL(serverInfo: ServerInfo, path: string, params?: MixRequestSearchParams): URL {
   const paramsList = []
   const safeParams = typeof params === 'undefined' ? {} : params
 
@@ -28,7 +28,9 @@ export default function buildURL(server: string, path: string, params?: MixReque
   let url
   try {
     const searchParams = new URLSearchParams(paramsList)
-    url = new URL(path, `https://${server}`)
+
+    // Adjust path based on tenant
+    url = new URL(`${serverInfo.pathPrefix}${path}`, `https://${serverInfo.server}`)
     url.search = searchParams.toString()
   } catch {
     throw new Error('invalid server URL; verify the value for apiServer in your configuration file.')

--- a/src/mix/client.ts
+++ b/src/mix/client.ts
@@ -13,7 +13,8 @@ import {
   MixClient,
   MixClientOptions,
   RequestArgs,
-  MixResponse} from './types'
+  MixResponse,
+  ServerInfo} from './types'
 
 const debug = makeDebug('mix:client')
 
@@ -22,9 +23,11 @@ const debug = makeDebug('mix:client')
  */
 export function createMixClient(options: MixClientOptions) {
   debug('createMixClient()')
+
   const {
-    userAgent = 'mix-js-client',
+    authFlow,
     server,
+    userAgent = 'mix-js-client',
   } = options
 
   let bearerToken = ''
@@ -40,9 +43,19 @@ export function createMixClient(options: MixClientOptions) {
 
   const client: MixClient = ({
     /** Returns the fully-qualified domain name of the Mix V4 API server */
-    getServer: () => {
+    getServer: (): ServerInfo => {
       debug('getServer()')
-      return server
+
+      // this is a hack to support systems that run with device code authentication
+      const pathPrefix = authFlow === 'device' ? '/v3/api' : ''
+
+      debug('server: %s', server)
+      debug('pathPrefix: %s', pathPrefix)
+
+      return {
+        server,
+        pathPrefix,
+      }
     },
 
     request: async (params: RequestArgs): Promise<MixResponse> => {

--- a/src/mix/types.ts
+++ b/src/mix/types.ts
@@ -130,9 +130,15 @@ export interface MixHeaders {
    * */
   'User-Agent': string;
 }
+
+export type ServerInfo = {
+  server: string;
+  pathPrefix: string;
+}
+
 export interface MixClient {
   /** Returns the fully-qualified domain name of the Mix V4 API server */
-  getServer: () => string
+  getServer: () => ServerInfo
 
   /** Sets the bearer token used for OAuth */
   setToken: (token: string) => void
@@ -142,6 +148,9 @@ export interface MixClient {
 }
 
 export interface MixClientOptions {
+  /** Authentication flow */
+  authFlow?: string
+
   /** Fully-qualified domain name of the Mix V4 API server */
   server: string;
 

--- a/src/utils/base/mix-command.ts
+++ b/src/utils/base/mix-command.ts
@@ -92,6 +92,7 @@ that configuration file swiftly.`)
     debug('this.options: %O', this.options)
 
     const options = {
+      authFlow: this.mixCLIConfig?.authFlow ?? '',
       userAgent: this.config.userAgent,
       server: this.mixCLIConfig?.apiServer ?? '',
     }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -113,16 +113,6 @@ export const eForbidden = (message: string) => {
     })
 }
 
-export const eInvalidValue = (message?: string, suggestions?: string[]) => {
-  return new MixCLIError(
-    message ?? 'One or more flags have invalid values.',
-    {
-      code: Codes.InvalidValue,
-      exit: 1,
-      suggestions: suggestions ?? ['verify the values passed to the command flags.'], // default
-    })
-}
-
 export const eInvalidColumn = (message?: string, suggestions?: string[]) => {
   return new MixCLIError(
     message ?? 'Invalid column name provided.',
@@ -130,6 +120,16 @@ export const eInvalidColumn = (message?: string, suggestions?: string[]) => {
       code: Codes.InvalidColumnError,
       exit: 1,
       suggestions: suggestions ? suggestions : ["verify the values passed to the 'columns' flag."],
+    })
+}
+
+export const eInvalidValue = (message?: string, suggestions?: string[]) => {
+  return new MixCLIError(
+    message ?? 'One or more flags have invalid values.',
+    {
+      code: Codes.InvalidValue,
+      exit: 1,
+      suggestions: suggestions ?? ['verify the values passed to the command flags.'], // default
     })
 }
 
@@ -221,6 +221,19 @@ export const eUnauthorized = (message?: string | null) => {
         'Your access token may have expired; renew it and retry.',
         `You may be trying to access data you do not have access to
   so verify the values you passed to the command flags.`,
+      ],
+    })
+}
+
+export const eUnauthorizedMSAL = (message?: string | null) => {
+  return new MixCLIError(
+    message ?? 'Unauthorized request.',
+    {
+      code: Codes.Unauthorized,
+      exit: authProblemExitCode,
+      suggestions: [
+        'You may have exceeded the time allowed to authenticate with the device code provided. Try again.',
+        'You may not have access to this system. Verify you have the right credentials.',
       ],
     })
 }

--- a/src/utils/msal-auth.ts
+++ b/src/utils/msal-auth.ts
@@ -1,0 +1,124 @@
+/*
+ * copyright 2024, nuance, inc. and its contributors.
+ * all rights reserved.
+ *
+ * this source code is licensed under the apache-2.0 license found in
+ * the license file in the root directory of this source tree.
+ */
+
+import makeDebug from 'debug'
+// eslint-disable-next-line node/no-missing-import
+import msal, {InteractionRequiredAuthError} from '@azure/msal-node'
+
+import getMSALCachePlugin from './msal-cache-plugin'
+
+const debug = makeDebug('mix:util:msal-auth')
+
+const AUTHENTICATION_TIMEOUT_SEC = 60
+
+export function getMSALClient(
+  {authority, configDir, clientId}:
+  {authority: string, configDir: string, clientId: string}): msal.PublicClientApplication | null {
+  debug('getMSALClient()')
+
+  const cacheFilePath = `${configDir}/msal-cache.json`
+  let cachePlugin: any
+
+  debug('cacheFilePath: %s', cacheFilePath)
+
+  let pca
+
+  try {
+    cachePlugin = getMSALCachePlugin(cacheFilePath)
+
+    const clientConfig = {
+      auth: {
+        clientId,
+        authority,
+      },
+      cache: {
+        cachePlugin,
+      },
+    }
+
+    pca = new msal.PublicClientApplication(clientConfig)
+  } catch (error) {
+    debug('failed to create MSAL client')
+    console.log(error)
+    return null
+  }
+
+  return pca
+}
+
+export async function getMSALTokenDeviceCode(options: any) {
+  const {
+    pca,
+    scope,
+    callback,
+  } = options
+
+  debug('getMSALTokenDeviceCode()')
+  const deviceCodeRequest = {
+    scopes: [scope],
+    deviceCodeCallback: callback,
+    timeout: AUTHENTICATION_TIMEOUT_SEC,
+  }
+
+  let response
+
+  try {
+    debug('acquiring token using device code flow')
+
+    response = await pca.acquireTokenByDeviceCode(deviceCodeRequest)
+  } catch (error) {
+    debug('failed to acquire token using device code flow')
+    console.log(error.message)
+    response = null
+  }
+
+  return response
+}
+
+export async function getMSALTokenSilent(options: any) {
+  const {
+    pca,
+    scope,
+    callback,
+  } = options
+
+  debug('getMSALTokenSilent()')
+  const accounts = await pca.getTokenCache().getAllAccounts()
+
+  let token
+
+  if (accounts.length === 1) {
+    debug('one account found in cache')
+
+    const [account] = accounts
+    const silentRequest = {account}
+
+    try {
+      token = pca.acquireTokenSilent(silentRequest)
+    } catch (error) {
+      debug('failed to acquire token silently')
+      if (error instanceof InteractionRequiredAuthError) {
+        debug('switching to device code flow')
+        console.log(error)
+        return getMSALTokenDeviceCode({pca, scope, callback})
+      }
+    }
+
+    debug('retrieved token from cache')
+    return token
+  }
+
+  // TODO: handle multiple accounts in cache
+  if (accounts.length > 1) {
+    debug('multiple accounts found in cache')
+    // this.error('Handling of multiple cached accounts not implemented yet')
+  } else {
+    debug('no account found in cache')
+    return null
+  }
+}

--- a/src/utils/msal-cache-plugin.ts
+++ b/src/utils/msal-cache-plugin.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * This was inspired from:
+ * https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-node
+ */
+import makeDebug from 'debug'
+
+import fs from 'node:fs'
+
+const debug = makeDebug('mix:utils:msal-cache-plugin')
+
+export default function getMSALCachePlugin(cacheLocation: string) {
+  debug('getMSALCachePlugin()')
+
+  const beforeCacheAccess = (cacheContext: any) => {
+    return new Promise<void>((resolve, reject) => {
+      if (fs.existsSync(cacheLocation)) {
+        fs.readFile(cacheLocation, 'utf-8', (err:any, data:any) => {
+          if (err) {
+            debug('error reading cache file: %O', err)
+            reject(err)
+          } else {
+            cacheContext.tokenCache.deserialize(data)
+            resolve()
+          }
+        })
+      } else {
+        debug('cache file does not exist: creating')
+        fs.writeFile(
+          cacheLocation,
+          cacheContext.tokenCache.serialize(),
+          (err: any) => {
+            if (err) {
+              debug('error writing cache file: %O', err)
+              reject(err)
+            }
+          },
+        )
+
+        resolve()
+      }
+    })
+  }
+
+  const afterCacheAccess = (cacheContext: { cacheHasChanged: any; tokenCache: { serialize: () => any } }) => {
+    return new Promise<void>((resolve, reject) => {
+      if (cacheContext.cacheHasChanged) {
+        debug('cache has changed: writing to file')
+        fs.writeFile(
+          cacheLocation,
+          cacheContext.tokenCache.serialize(),
+          (err: any) => {
+            if (err) {
+              reject(err)
+            }
+
+            resolve()
+          },
+        )
+      } else {
+        debug('cache has not changed')
+        resolve()
+      }
+    })
+  }
+
+  return {
+    beforeCacheAccess,
+    afterCacheAccess,
+  }
+}

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -13,6 +13,7 @@ const mixAPIServer = 'mix-api.example.com'
 export const mixAPIServerURL = `https://${mixAPIServer}`
 
 const currentConfig = {
+  authFlow: 'credentials',
   authServer: 'auth.example.com',
   clientId: crypto.randomUUID(),
   clientSecret: crypto.randomUUID(),


### PR DESCRIPTION
This PR adds support for the device code authentication flow.

To add a system that uses device code authentication flow,
run the `init` command and answer `device` to the
"Authentication flow?" question.

Once a system is added using the `init` command, the other
commands can be used the same way they are used with systems
that support the client credentials grant flow.